### PR TITLE
Add Time Zone Support

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -1,4 +1,5 @@
 var UUID = require('uuid/v4');
+var moment = require('moment-timezone');
 
 (function(name, definition) {
 
@@ -147,6 +148,24 @@ var UUID = require('uuid/v4');
             parseInt(comps[6], 10 )
           ));
           // TODO add tz
+        } else if (params && params[0] && params[0].indexOf('TZID=') > -1 && params[0].split('=')[1]) {
+          var tz = params[0].split('=')[1];
+          //lookup tz
+          var found = moment.tz.names().filter(function(zone) { return zone === tz; })[0];
+          if (found) {
+            var zoneDate = moment.tz(val, 'YYYYMMDDTHHmmss', tz);
+            newDate = zoneDate.toDate();
+          } else {
+            //fallback if tz not found
+            newDate = new Date(
+              parseInt(comps[1], 10),
+              parseInt(comps[2], 10)-1,
+              parseInt(comps[3], 10),
+              parseInt(comps[4], 10),
+              parseInt(comps[5], 10),
+              parseInt(comps[6], 10)
+            );
+          }
         } else {
           newDate = new Date(
             parseInt(comps[1], 10),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git://github.com/jens-maus/node-ical.git"
   },
   "dependencies": {
+    "moment-timezone": "^0.5.23",
     "request": "^2.88.0",
     "rrule": "^2.5.6",
     "uuid": "^3.3.2"

--- a/test/test.js
+++ b/test/test.js
@@ -210,7 +210,7 @@ vows.describe('node-ical').addBatch({
       }
       , 'has a start' : function(topic){
         assert.equal(topic.start.tz, 'America/Phoenix')
-        assert.equal(topic.start.toISOString(), new Date(2011, 10, 09, 19, 0,0).toISOString())
+        assert.equal(topic.start.toISOString(), new Date(Date.UTC(2011, 10, 10, 02, 0,0)).toISOString())
       }
     }
   }
@@ -408,13 +408,13 @@ vows.describe('node-ical').addBatch({
       }
       , "Has two EXDATES": function (topic) {
       	assert.notEqual(topic.exdate, undefined);
-      	assert.notEqual(topic.exdate[new Date(2015, 06, 08, 12, 0, 0).toISOString()], undefined);
-      	assert.notEqual(topic.exdate[new Date(2015, 06, 10, 12, 0, 0).toISOString()], undefined);
+      	assert.notEqual(topic.exdate[new Date(Date.UTC(2015, 06, 08, 19, 0, 0)).toISOString()], undefined);
+      	assert.notEqual(topic.exdate[new Date(Date.UTC(2015, 06, 10, 19, 0, 0)).toISOString()], undefined);
       }
       , "Has a RECURRENCE-ID override": function (topic) {
       	assert.notEqual(topic.recurrences, undefined);
-      	assert.notEqual(topic.recurrences[new Date(2015, 06, 07, 12, 0, 0).toISOString()], undefined);
-      	assert.equal(topic.recurrences[new Date(2015, 06, 07, 12, 0, 0).toISOString()].summary, 'More Treasure Hunting');
+      	assert.notEqual(topic.recurrences[new Date(Date.UTC(2015, 06, 07, 19, 0, 0)).toISOString()], undefined);
+      	assert.equal(topic.recurrences[new Date(Date.UTC(2015, 06, 07, 19, 0, 0)).toISOString()].summary, 'More Treasure Hunting');
       }
     }
   }
@@ -437,8 +437,8 @@ vows.describe('node-ical').addBatch({
       }
       , "Has a RECURRENCE-ID override": function (topic) {
       	assert.notEqual(topic.recurrences, undefined);
-      	assert.notEqual(topic.recurrences[new Date(2016, 7 ,26, 14, 0, 0).toISOString()], undefined);
-      	assert.equal(topic.recurrences[new Date(2016, 7, 26, 14, 0, 0).toISOString()].summary, 'bla bla');
+      	assert.notEqual(topic.recurrences[new Date(Date.UTC(2016, 7 ,26, 11, 0, 0)).toISOString()], undefined);
+      	assert.equal(topic.recurrences[new Date(Date.UTC(2016, 7, 26, 11, 0, 0)).toISOString()].summary, 'bla bla');
       }
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -118,6 +118,15 @@ vows.describe('node-ical').addBatch({
         assert.equal(topic.end.getUTCMinutes(), 30);
       }
     }
+    , 'tzid parsing' : {
+      topic: function(events) {
+        return _.filter(events,function(obj) { { return obj.uid == 'EC9439B1-FF65-11D6-9973-003065F99D04'; } })[0];
+      }
+      , 'tzid offset correctly applied' : function(event) {
+        var start = new Date('2002-10-28T22:00:00.000Z');
+        assert.equal(event.start.valueOf(), start.valueOf());
+      }
+    }
   }
   , 'with test3.ics (testing tvcountdown.com)' : {
     topic: function() {

--- a/test/testAsync.js
+++ b/test/testAsync.js
@@ -125,6 +125,15 @@ vows.describe('node-ical').addBatch({
         assert.equal(topic.end.getUTCMinutes(), 30);
       }
     }
+    , 'tzid parsing' : {
+      topic: function(events) {
+        return _.filter(events,function(obj) { { return obj.uid == 'EC9439B1-FF65-11D6-9973-003065F99D04'; } })[0];
+      }
+      , 'tzid offset correctly applied' : function(event) {
+        var start = new Date('2002-10-28T22:00:00.000Z');
+        assert.equal(event.start.valueOf(), start.valueOf());
+      }
+    }
   }
   , 'with test3.ics (testing tvcountdown.com)' : {
     topic: function() {

--- a/test/testAsync.js
+++ b/test/testAsync.js
@@ -226,7 +226,7 @@ vows.describe('node-ical').addBatch({
       }
       , 'has a start' : function(topic){
         assert.equal(topic.start.tz, 'America/Phoenix')
-        assert.equal(topic.start.toISOString(), new Date(2011, 10, 09, 19, 0,0).toISOString())
+        assert.equal(topic.start.toISOString(), new Date(Date.UTC(2011, 10, 10, 02, 0,0)).toISOString())
       }
     }
   }
@@ -448,13 +448,13 @@ vows.describe('node-ical').addBatch({
       }
       , "Has two EXDATES": function (topic) {
       	assert.notEqual(topic.exdate, undefined);
-      	assert.notEqual(topic.exdate[new Date(2015, 06, 08, 12, 0, 0).toISOString()], undefined);
-      	assert.notEqual(topic.exdate[new Date(2015, 06, 10, 12, 0, 0).toISOString()], undefined);
+      	assert.notEqual(topic.exdate[new Date(Date.UTC(2015, 06, 08, 19, 0, 0)).toISOString()], undefined);
+      	assert.notEqual(topic.exdate[new Date(Date.UTC(2015, 06, 10, 19, 0, 0)).toISOString()], undefined);
       }
       , "Has a RECURRENCE-ID override": function (topic) {
       	assert.notEqual(topic.recurrences, undefined);
-      	assert.notEqual(topic.recurrences[new Date(2015, 06, 07, 12, 0, 0).toISOString()], undefined);
-      	assert.equal(topic.recurrences[new Date(2015, 06, 07, 12, 0, 0).toISOString()].summary, 'More Treasure Hunting');
+      	assert.notEqual(topic.recurrences[new Date(Date.UTC(2015, 06, 07, 19, 0, 0)).toISOString()], undefined);
+      	assert.equal(topic.recurrences[new Date(Date.UTC(2015, 06, 07, 19, 0, 0)).toISOString()].summary, 'More Treasure Hunting');
       }
     }
   }
@@ -480,8 +480,8 @@ vows.describe('node-ical').addBatch({
       }
       , "Has a RECURRENCE-ID override": function (topic) {
       	assert.notEqual(topic.recurrences, undefined);
-      	assert.notEqual(topic.recurrences[new Date(2016, 7 ,26, 14, 0, 0).toISOString()], undefined);
-      	assert.equal(topic.recurrences[new Date(2016, 7, 26, 14, 0, 0).toISOString()].summary, 'bla bla');
+      	assert.notEqual(topic.recurrences[new Date(Date.UTC(2016, 7 ,26, 11, 0, 0)).toISOString()], undefined);
+      	assert.equal(topic.recurrences[new Date(Date.UTC(2016, 7, 26, 11, 0, 0)).toISOString()].summary, 'bla bla');
       }
     }
   }


### PR DESCRIPTION
This PR adds support for parsing and applying TZID on dates. It uses `moment-timezone` and its built-in time zones for parsing. These are the changes I've made:

* Added branch if non-UTC (doesn't end with `Z`) to parse the TZID. If the TZID isn't supported by `moment-timezone` it falls back to existing behavior.
* Added test `tzid-parsing`
* Modified existing tests that perform date equality to consider time zone offset

While developing this patch, I found that there are a few examples that contain non-standard time zones:

* `test9.ics` - Time zone is surrounded by quotes. Per [RFC 5545 3.2.19](https://tools.ietf.org/html/rfc5545#section-3.2.19), TZID appears unquoted. This is observed behavior in both iOS and Android clients.
* `test14.ics` - Time zone is quoted and contains the UTC offset in parentheses.

Instead of modifying the test data, I added a lookup to see whether the incoming time zone is recognized by `moment-timezone`, and otherwise falling back to existing behavior.

Because this changes the output of the parsed iCal files, I would recommend incrementing the major version. However, I'll defer to you.

Let me know if you have any questions/comments/concerns. Thank you very much for your work on this excellent library.