### PR TITLE
lock rrule version to 2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,54 +1,54 @@
 {
-  "name": "node-ical",
-  "version": "0.11.3",
-  "main": "node-ical.js",
-  "types": "node-ical.d.ts",
-  "description": "NodeJS class for parsing iCalendar/ICS files",
-  "keywords": [
-    "ical",
-    "ics",
-    "calendar",
-    "nodejs"
-  ],
-  "homepage": "https://github.com/jens-maus/node-ical",
-  "author": "Jens Maus <mail@jens-maus.de>",
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/jens-maus/node-ical.git"
-  },
-  "dependencies": {
-    "moment-timezone": "^0.5.31",
-    "request": "^2.88.2",
-    "rrule": "^2.6.4",
-    "uuid": "^3.3.2"
-  },
-  "devDependencies": {
-    "@types/request": "^2.48.3",
-    "diff": ">=3.5.0",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.3.0",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-prettier": "^3.1.1",
-    "prettier": "^1.19.1",
-    "underscore": "1.9.1",
-    "vows": "^0.8.2",
-    "xo": "^0.18.2",
-    "pre-commit": "^1.2.2"
-  },
-  "xo": {
-    "space": 2
-  },
-  "pre-commit": [
-    "lintfix"
-  ],
-  "scripts": {
-    "test": "xo; vows test/test.js && vows test/test-async.js && printf \"\\n\"",
-    "lint": "xo",
-    "lintfix": "xo --fix",
-    "format-check": "prettier --config .prettierrc.js --check *.js test/*.js",
-    "format": "prettier --config .prettierrc.js --write *.js test/*.js",
-    "precommit": "npm run format && npm run fix"
-  },
-  "readmeFilename": "README.md"
+    "name": "node-ical",
+    "version": "0.11.3",
+    "main": "node-ical.js",
+    "types": "node-ical.d.ts",
+    "description": "NodeJS class for parsing iCalendar/ICS files",
+    "keywords": [
+        "ical",
+        "ics",
+        "calendar",
+        "nodejs"
+    ],
+    "homepage": "https://github.com/jens-maus/node-ical",
+    "author": "Jens Maus <mail@jens-maus.de>",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/jens-maus/node-ical.git"
+    },
+    "dependencies": {
+        "moment-timezone": "^0.5.31",
+        "request": "^2.88.2",
+        "rrule": "2.6.4",
+        "uuid": "^3.3.2"
+    },
+    "devDependencies": {
+        "@types/request": "^2.48.3",
+        "diff": ">=3.5.0",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.3.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-prettier": "^3.1.1",
+        "prettier": "^1.19.1",
+        "underscore": "1.9.1",
+        "vows": "^0.8.2",
+        "xo": "^0.18.2",
+        "pre-commit": "^1.2.2"
+    },
+    "xo": {
+        "space": 2
+    },
+    "pre-commit": [
+        "lintfix"
+    ],
+    "scripts": {
+        "test": "xo; vows test/test.js && vows test/test-async.js && printf \"\\n\"",
+        "lint": "xo",
+        "lintfix": "xo --fix",
+        "format-check": "prettier --config .prettierrc.js --check *.js test/*.js",
+        "format": "prettier --config .prettierrc.js --write *.js test/*.js",
+        "precommit": "npm run format && npm run fix"
+    },
+    "readmeFilename": "README.md"
 }


### PR DESCRIPTION
Deprecated package rrule is broken and appears it may not receive a fix. Update node-ical's package.json to use the recommended version from rrule's author (https://www.npmjs.com/package/rrule)