### PR TITLE
Update ical.js

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -478,7 +478,7 @@ module.exports = {
             }
 
             // If the date has an toISOString function
-            if (typeof curr.start.toISOString === 'function') {
+            if (curr.start && typeof curr.start.toISOString === 'function') {
               try {
                 rule += `;DTSTART=${curr.start.toISOString().replace(/[-:]/g, '')}`;
                 rule = rule.replace(/\.\d{3}/, '');


### PR DESCRIPTION
Check for cases where curr.start might be empty ... see https://sentry.iobroker.net/share/issue/47cdbfffaa254f2bad990373f01e13c4/

```
TypeError: Cannot read property 'toISOString' of undefined
  File "/opt/iobroker/node_modules/iobroker.ical/node_modules/node-ical/ical.js", line 464, col 35, in Object.END
    if (typeof curr.start.toISOString === 'function') {
  File "/opt/iobroker/node_modules/iobroker.ical/node_modules/node-ical/ical.js", line 514, col 39, in Object.handleObject
    return self.objectHandlers[name](value, parameters, ctx, stack, line);
  File "/opt/iobroker/node_modules/iobroker.ical/node_modules/node-ical/ical.js", line 568, col 18, in Object.parseLines
    ctx = self.handleObject(name, value, parameters, ctx, stack, l) || {};
  File "/opt/iobroker/node_modules/iobroker.ical/node_modules/node-ical/ical.js", line 583, col 16, in Immediate.<anonymous>
    self.parseLines(lines, limit, ctx, stack, i + 1, cb);
  File "internal/timers.js", line 456, col 21, in processImmediate
```