### PR TITLE
Adds recurrences object to VEvent type

### DIFF
--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -82,6 +82,7 @@ declare module 'node-ical' {
     lastmodified: DateWithTimeZone;
     rrule?: RRule;
     attendee?: Attendee[] | Attendee;
+    recurrences?: {[dateKey: string]: Omit<VEvent, 'recurrences'>};
 
     // I am not entirely sure about these, leave them as any for now..
     organizer: Organizer;


### PR DESCRIPTION
Adds missing `recurrences` property to VEvent object type.

See lines https://github.com/jens-maus/node-ical/blob/master/ical.js#L462 and following