### PR TITLE
Always parse Line endings with \r?\n

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -20,10 +20,6 @@ const text = function (t = '') {
     .replace(/\\\\/g, '\\');
 };
 
-const normalizeLineEndings = function (string, normalized = '\r\n') {
-  return string.replace(/\r?\n/g, normalized);
-};
-
 const parseValue = function (value) {
   if (value === 'TRUE') {
     return true;
@@ -709,7 +705,7 @@ module.exports = {
   },
 
   parseICS(string, cb) {
-    const lines = normalizeLineEndings(string);
+    const lines = string.split(/\r?\n/);
     let ctx;
 
     if (cb) {

--- a/ical.js
+++ b/ical.js
@@ -20,9 +20,9 @@ const text = function (t = '') {
     .replace(/\\\\/g, '\\');
 };
 
-const normalizeLineEndings = function (str, normalized = '\r\n') {
-  return str.replace(/\r?\n/g, normalized);
-}
+const normalizeLineEndings = function (string, normalized = '\r\n') {
+  return string.replace(/\r?\n/g, normalized);
+};
 
 const parseValue = function (value) {
   if (value === 'TRUE') {

--- a/ical.js
+++ b/ical.js
@@ -20,6 +20,10 @@ const text = function (t = '') {
     .replace(/\\\\/g, '\\');
 };
 
+const normalizeLineEndings = function (str, normalized = '\r\n') {
+  return str.replace(/\r?\n/g, normalized);
+}
+
 const parseValue = function (value) {
   if (value === 'TRUE') {
     return true;
@@ -704,27 +708,8 @@ module.exports = {
     }
   },
 
-  getLineBreakChar(string) {
-    const indexOfLF = string.indexOf('\n', 1); // No need to check first-character
-
-    if (indexOfLF === -1) {
-      if (string.includes('\r')) {
-        return '\r';
-      }
-
-      return '\n';
-    }
-
-    if (string[indexOfLF - 1] === '\r') {
-      return '\r?\n';
-    }
-
-    return '\n';
-  },
-
   parseICS(string, cb) {
-    const lineEndType = this.getLineBreakChar(string);
-    const lines = string.split(lineEndType === '\n' ? /\n/ : /\r?\n/);
+    const lines = normalizeLineEndings(string);
     let ctx;
 
     if (cb) {


### PR DESCRIPTION
fixes #173

Question left is: Why it was trying to detect the linetypes before? because if \r\n was detected it already was allowing "both" line endings ...