### PR TITLE
`Customized Time Zone` returns undefined

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -116,8 +116,8 @@ function getIanaTZFromMS(msTZName) {
 function getTimeZone(value) {
   let tz = value;
   let found = '';
-  // If this is the custom timezone from MS Outlook
-  if (tz === 'tzone://Microsoft/Custom') {
+  // If this is a custom timezone from MS Outlook / Exchange
+  if (['tzone://Microsoft/Custom', 'Customized Time Zone'].includes(tz)) {
     // Set it to the local timezone, cause we can't tell
     tz = moment.tz.guess();
   }
@@ -151,7 +151,13 @@ function getTimeZone(value) {
     });
   }
 
-  return found === '' ? tz : found;
+  // If timezone not found in moment, return the timezone value we got in or the timezone value guessed by moment
+  if (!found) {
+    return tz;
+  }
+
+  // Return the timezone found through Iana
+  return found;
 }
 
 function isDateOnly(value, parameters) {
@@ -218,8 +224,8 @@ const dateParameter = function (name) {
         let found = '';
         let offset = '';
 
-        // If this is the custom timezone from MS Outlook
-        if (tz === 'tzone://Microsoft/Custom') {
+        // If this is a custom timezone from MS Outlook / Exchange
+        if (['tzone://Microsoft/Custom', 'Customized Time Zone'].includes(tz)) {
           // Set it to the local timezone, cause we can't tell
           tz = moment.tz.guess();
           parameters[0] = 'TZID=' + tz;

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -628,10 +628,11 @@ vows
             return x.summary === '[private]';
           })[0];
         },
-        'is not valid timezone'(topic) {
-          assert.equal(topic.start.tz, 'Customized Time Zone');
+        'timezone will not be "Customized Time Zone"'(topic) {
+          assert.notEqual(topic.start.tz, 'Customized Time Zone');
+          assert.notEqual(topic.start.tz, undefined);
         },
-        'rrule tzid is not "undefined"'(topic) {
+        'rrule tzid will not be "undefined"'(topic) {
           assert.notEqual(topic.rrule.origOptions.tzid, undefined);
         }
       }

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -630,6 +630,9 @@ vows
         },
         'is not valid timezone'(topic) {
           assert.equal(topic.start.tz, 'Customized Time Zone');
+        },
+        'rrule tzid is not "undefined"'(topic) {
+          assert.notEqual(topic.rrule.origOptions.tzid, undefined);
         }
       }
     },

--- a/test/test.js
+++ b/test/test.js
@@ -749,6 +749,9 @@ vows
         },
         'is not valid timezone'(topic) {
           assert.equal(topic.start.tz, 'Customized Time Zone');
+        },
+        'rrule tzid is not "undefined"'(topic) {
+          assert.notEqual(topic.rrule.origOptions.tzid, undefined);
         }
       }
     },

--- a/test/test.js
+++ b/test/test.js
@@ -747,10 +747,11 @@ vows
             return x.summary === '[private]';
           })[0];
         },
-        'is not valid timezone'(topic) {
-          assert.equal(topic.start.tz, 'Customized Time Zone');
+        'timezone will not be "Customized Time Zone"'(topic) {
+          assert.notEqual(topic.start.tz, 'Customized Time Zone');
+          assert.notEqual(topic.start.tz, undefined);
         },
-        'rrule tzid is not "undefined"'(topic) {
+        'rrule tzid will not be "undefined"'(topic) {
           assert.notEqual(topic.rrule.origOptions.tzid, undefined);
         }
       }


### PR DESCRIPTION
## The problem

If **TZID** is set to `Customized Time Zone` for *DTSTART*, this would result in timezone set on the rrule string to be `undefined`, making the rrule string invalid which will result in an rrule object where `origOptions.tzid` and `options.tzid` is set to `undefined`

This will make a call to `event.rrule.between` return an array of `Invalid date`

**RRule string**: `FREQ=WEEKLY;UNTIL=20220630T063000Z;INTERVAL=1;BYDAY=TH;WKST=MO;DTSTART;TZID=undefined:20220203T083000Z`

**RRule object**:
```json
{
    _cache: Cache { all: false, before: [], after: [], between: [Array] },
    origOptions: {
      tzid: 'undefined',
      dtstart: 2022-02-03T08:30:00.000Z,
      freq: 2,
      until: 2022-06-30T06:30:00.000Z,
      interval: 1,
      byweekday: [Array],
      wkst: [Weekday]
    },
    options: {
      freq: 2,
      dtstart: 2022-02-03T08:30:00.000Z,
      interval: 1,
      wkst: 0,
      count: null,
      until: 2022-06-30T06:30:00.000Z,
      tzid: 'undefined',
      bysetpos: null,
      bymonth: null,
      bymonthday: [],
      bynmonthday: [],
      byyearday: null,
      byweekno: null,
      byweekday: [Array],
      bynweekday: null,
      byhour: [Array],
      byminute: [Array],
      bysecond: [Array],
      byeaster: null
    }
}
```

## The fix

By changing line 120<br>
from: `if (tz === 'tzone://Microsoft/Custom') {`<br>
to: `if (['tzone://Microsoft/Custom', 'Customized Time Zone'].includes(tz)) {`<br>
this will make **moment** guess the timezone to use.

This seems to work as it should, at least when running on environments where **TZ=UTC**