### PR TITLE
Handle "(no TZ description)" in TZ

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -219,7 +219,7 @@ const dateParameter = function (name) {
         let offset = '';
 
         // If this is the custom timezone from MS Outlook
-        if (tz === 'tzone://Microsoft/Custom') {
+        if (tz === 'tzone://Microsoft/Custom' || tz === '(no TZ description)') {
           // Set it to the local timezone, cause we can't tell
           tz = moment.tz.guess();
           parameters[0] = 'TZID=' + tz;


### PR DESCRIPTION
My MagicMirror instance was failing because one of the iCal feeds from my Exchange calendar had this value. This change addressed the issue locally.