### PR TITLE
Break Attendee unions into separate types

### DIFF
--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -134,13 +134,17 @@ declare module 'node-ical' {
   }>;
 
   export type Attendee = Property<{
-    CUTYPE?: 'INDIVIDUAL' | 'UNKNOWN' | 'GROUP' | 'ROOM' | string;
-    ROLE?: 'CHAIR' | 'REQ-PARTICIPANT' | 'NON-PARTICIPANT' | string;
-    PARTSTAT?: 'NEEDS-ACTION' | 'ACCEPTED' | 'DECLINED' | 'TENTATIVE' | 'DELEGATED';
+    CUTYPE?: AttendeeCUType;
+    ROLE?: AttendeeRole;
+    PARTSTAT?: AttendeePartStat;
     RSVP?: boolean;
     CN?: string;
     'X-NUM-GUESTS'?: number;
   }>;
+
+  export type AttendeeCUType = 'INDIVIDUAL' | 'UNKNOWN' | 'GROUP' | 'ROOM' | string;
+  export type AttendeeRole = 'CHAIR' | 'REQ-PARTICIPANT' | 'NON-PARTICIPANT' | string;
+  export type AttendeePartStat = 'NEEDS-ACTION' | 'ACCEPTED' | 'DECLINED' | 'TENTATIVE' | 'DELEGATED';
 
   export type DateWithTimeZone = Date & {tz: string};
   export type DateType = 'date-time' | 'date';


### PR DESCRIPTION
This is a pretty small CR. 

I'm doing some stuff where I really want to construct some tagged unions based from the values of `Attendee` records.  They're not exported as their own types though, so I have to do a wonky work around to narrow the types used on  `Attendee` for use in my own code.


It would be a lot cleaner and easier if those types were just exported in the first place.  So I did that.