### PR TITLE
for files with multiple tzids in the VTIMEZONE, choose the last

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -298,8 +298,13 @@ const dateParameter = function (name) {
         const vTimezone =
           Object.values(stackItemWithTimeZone).find(({type}) => type === 'VTIMEZONE');
 
-        newDate = vTimezone && moment.tz.zone(vTimezone.tzid) ?
-          moment.tz(value, 'YYYYMMDDTHHmmss', vTimezone.tzid).toDate() :
+        // if the VTIMEZONE contains multiple TZIDs, use the last one in order
+        const normalizedTzId = vTimezone ? 
+          typeof vTimezone.tzid == 'object' ? vTimezone.tzid[vTimezone.tzid.length - 1] : vTimezone.tzid :
+          null;
+
+        newDate = normalizedTzId && moment.tz.zone(normalizedTzId) ?
+          moment.tz(value, 'YYYYMMDDTHHmmss', normalizedTzId).toDate() :
           new Date(
             Number.parseInt(comps[1], 10),
             Number.parseInt(comps[2], 10) - 1,

--- a/ical.js
+++ b/ical.js
@@ -298,9 +298,9 @@ const dateParameter = function (name) {
         const vTimezone =
           Object.values(stackItemWithTimeZone).find(({type}) => type === 'VTIMEZONE');
 
-        // if the VTIMEZONE contains multiple TZIDs, use the last one in order
-        const normalizedTzId = vTimezone ? 
-          Array.isArray(vTimezone.tzid) ? vTimezone.tzid[vTimezone.tzid.length - 1] : vTimezone.tzid :
+        // If the VTIMEZONE contains multiple TZIDs, use the last one in order
+        const normalizedTzId = vTimezone ?
+          (Array.isArray(vTimezone.tzid) ? vTimezone.tzid[vTimezone.tzid.length - 1] : vTimezone.tzid) :
           null;
 
         newDate = normalizedTzId && moment.tz.zone(normalizedTzId) ?

--- a/ical.js
+++ b/ical.js
@@ -300,7 +300,7 @@ const dateParameter = function (name) {
 
         // if the VTIMEZONE contains multiple TZIDs, use the last one in order
         const normalizedTzId = vTimezone ? 
-          typeof vTimezone.tzid == 'object' ? vTimezone.tzid[vTimezone.tzid.length - 1] : vTimezone.tzid :
+          Array.isArray(vTimezone.tzid) ? vTimezone.tzid[vTimezone.tzid.length - 1] : vTimezone.tzid :
           null;
 
         newDate = normalizedTzId && moment.tz.zone(normalizedTzId) ?

--- a/test/test.js
+++ b/test/test.js
@@ -983,6 +983,22 @@ vows
           assert.equal(topic.start.tz, 'Europe/Berlin');
         }
       }
+    },
+    'with test_with_multiple_tzids_in_vtimezone.ics': {
+      topic() {
+        return ical.parseFile('./test/test_with_multiple_tzids_in_vtimezone.ics');
+      },
+      'using a vtimezone with multiple timezone': {
+        topic(events) {
+          return _.select(_.values(events), x => {
+            return x.uid === '1891-1709856000-1709942399@www.washougal.k12.wa.us';
+          })[0];
+        },
+        'has a start'(topic) {
+          assert.equal(topic.start.toJSON(), '2024-06-27T07:00:00.000Z');
+          assert.equal(topic.end.toJSON(), '2024-06-28T06:00:00.000Z');
+        }
+      }
     }
   })
   .export(module);

--- a/test/test_with_multiple_tzids_in_vtimezone.ics
+++ b/test/test_with_multiple_tzids_in_vtimezone.ics
@@ -1,0 +1,46 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Hathaway Elementary School - ECPv6.3.3//NONSGML v1.0//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Hathaway Elementary School
+X-ORIGINAL-URL:https://www.washougal.k12.wa.us/hathaway
+X-WR-CALDESC:Events for Hathaway Elementary School
+REFRESH-INTERVAL;VALUE=DURATION:PT1H
+X-Robots-Tag:noindex
+X-PUBLISHED-TTL:PT1H
+BEGIN:VTIMEZONE
+TZID:Africa/Abidjan
+BEGIN:STANDARD
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:20240101T000000
+END:STANDARD
+TZID:America/Los_Angeles
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0800
+TZOFFSETTO:-0700
+TZNAME:PDT
+DTSTART:20240310T100000
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0700
+TZOFFSETTO:-0800
+TZNAME:PST
+DTSTART:20241103T090000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART:20240627T000000
+DTEND:20240627T230000
+DTSTAMP:20240222T162327
+CREATED:20231129T014844Z
+LAST-MODIFIED:20240222T184259Z
+UID:1891-1709856000-1709942399@www.washougal.k12.wa.us
+SUMMARY:Possible Snow Makeup Day
+DESCRIPTION:This day is a snow makeup day\, and will be added back to the calendar if needed. If we do not have any snow closure\, this is a non-attendance day for students.  \nFor a list of all calendar related closures and important dates\, please visit our calendar page at https://www.washougal.k12.wa.us/calendar/
+URL:https://www.washougal.k12.wa.us/hathaway/event/possible-snow-makeup-day/
+CATEGORIES:School Events
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
This is looking to resolve an issue with node-ical parsing https://www.washougal.k12.wa.us/hathaway/calendars/category/school-events/?post_type=tribe_events&ical=1&eventDisplay=list

Here are the key facts as I understand right now:
* The school calendar feed had multiple TZIDs defined in a single VTIMEZONE block.
  * This [seems to be against the spec](https://icalendar.org/iCalendar-RFC-5545/3-6-5-time-zone-component.html)
  * The validator at [icalendar.org](http://icalendar.org/) considers [this feed to be valid](https://icalendar.org/validator.html?url=https://www.washougal.k12.wa.us/hathaway/calendars/category/school-events/?post_type=tribe_events&ical=1&eventDisplay=list). ¯\\\_(ツ)\_/¯
* The node-ical library doesn’t handle multiple TZIDs - it expects a string, gets an array and causes the error when trying to use moment-timezone with the array.
* The workaround detects the object instead of a string, then simply selects the last tzid in the block.
  * This maybe is too naive - might be better to see which TZID is defined with more subblocks or more precision - e.g. take one with STANDARD & DAYLIGHT blocks over one that has only a STANDARD block… not sure if that’s better, though. Thought that feels a little arbitrary, too.

Appreciate any feedback on how best to account for this. If you have any insight on why the icalendar validator thinks the feed is ok, even though it seems to violate my understanding of the VTIMEZONE requirements, that would also be interesting to understand.