### PR TITLE
fix: correct UTC time shift bug in RRULE expansion

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -569,11 +569,7 @@ module.exports = {
             try {
               // If the original date has a TZID, add it
               // BUT: UTC (Etc/UTC, UTC, Etc/GMT) should use ISO format with Z, not TZID
-              const isUtc = curr.start.tz && (
-                curr.start.tz === 'Etc/UTC'
-                || curr.start.tz === 'UTC'
-                || curr.start.tz === 'Etc/GMT'
-              );
+              const isUtc = tzUtil.isUtcTimezone(curr.start.tz);
 
               if (curr.start.tz && !isUtc) {
                 const tzInfo = tzUtil.resolveTZID(curr.start.tz);

--- a/ical.js
+++ b/ical.js
@@ -568,7 +568,14 @@ module.exports = {
           if (curr.start && typeof curr.start.toISOString === 'function') {
             try {
               // If the original date has a TZID, add it
-              if (curr.start.tz) {
+              // BUT: UTC (Etc/UTC, UTC, Etc/GMT) should use ISO format with Z, not TZID
+              const isUtc = curr.start.tz && (
+                curr.start.tz === 'Etc/UTC'
+                || curr.start.tz === 'UTC'
+                || curr.start.tz === 'Etc/GMT'
+              );
+
+              if (curr.start.tz && !isUtc) {
                 const tzInfo = tzUtil.resolveTZID(curr.start.tz);
                 const localStamp = tzUtil.formatDateForRrule(curr.start, tzInfo);
                 const tzidLabel = tzInfo.iana || tzInfo.etc || tzInfo.original;

--- a/test/snapshots/example-rrule-basic.txt
+++ b/test/snapshots/example-rrule-basic.txt
@@ -1,11 +1,12 @@
 summary:Daily focus block
-start:2024-01-01T11:00:00.000Z
-end:2024-01-01T12:00:00.000Z
+start:2024-01-01T10:00:00.000Z
+end:2024-01-01T11:00:00.000Z
 
 summary:Daily focus block
-start:2024-01-02T11:00:00.000Z
-end:2024-01-02T12:00:00.000Z
+start:2024-01-02T10:00:00.000Z
+end:2024-01-02T11:00:00.000Z
 
 summary:Daily focus block
-start:2024-01-03T11:00:00.000Z
-end:2024-01-03T12:00:00.000Z
+start:2024-01-03T10:00:00.000Z
+end:2024-01-03T11:00:00.000Z
+

--- a/test/tz-utils.test.js
+++ b/test/tz-utils.test.js
@@ -111,4 +111,30 @@ describe('unit: tz-utils', () => {
       }
     }
   });
+
+  describe('isUtcTimezone', () => {
+    it('should return false for undefined/null/empty', () => {
+      assert.equal(tz.__test__.isUtcTimezone(undefined), false);
+      assert.equal(tz.__test__.isUtcTimezone(null), false);
+      assert.equal(tz.__test__.isUtcTimezone(''), false);
+    });
+
+    it('should return true for UTC timezones', () => {
+      assert.equal(tz.__test__.isUtcTimezone('Etc/UTC'), true);
+      assert.equal(tz.__test__.isUtcTimezone('UTC'), true);
+      assert.equal(tz.__test__.isUtcTimezone('Etc/GMT'), true);
+    });
+
+    it('should be case insensitive', () => {
+      assert.equal(tz.__test__.isUtcTimezone('etc/utc'), true);
+      assert.equal(tz.__test__.isUtcTimezone('utc'), true);
+      assert.equal(tz.__test__.isUtcTimezone('ETC/GMT'), true);
+    });
+
+    it('should return false for non-UTC timezones', () => {
+      assert.equal(tz.__test__.isUtcTimezone('Europe/Berlin'), false);
+      assert.equal(tz.__test__.isUtcTimezone('America/New_York'), false);
+      assert.equal(tz.__test__.isUtcTimezone('Etc/GMT+1'), false);
+    });
+  });
 });

--- a/tz-utils.js
+++ b/tz-utils.js
@@ -663,9 +663,20 @@ module.exports = {
   resolveTZID,
   formatDateForRrule,
   attachTz,
+  isUtcTimezone,
 };
 
 // Expose some internals for testing
 module.exports.__test__ = {
   normalizeMidnightParts,
+  isUtcTimezone,
 };
+
+function isUtcTimezone(tz) {
+  if (!tz) {
+    return false;
+  }
+
+  const tzLower = tz.toLowerCase();
+  return tzLower === 'etc/utc' || tzLower === 'utc' || tzLower === 'etc/gmt';
+}


### PR DESCRIPTION
## Problem

When parsing iCalendar events with UTC timestamps (DTSTART with `Z` suffix like `20240101T100000Z`), node-ical was incorrectly treating them as having a TZID of `Etc/UTC`. This caused `formatDateForRrule()` to generate a DTSTART without the `Z` suffix, which rrule.js then interpreted as local time instead of UTC, resulting in a 1-hour shift.

**Example:**
```
ICS: DTSTART:20240101T100000Z  (10:00 UTC)
Before: event.rrule.between() → 11:00 UTC ❌
After:  event.rrule.between() → 10:00 UTC ✅
```

## Solution

Detect UTC timezones (`Etc/UTC`, `UTC`, `Etc/GMT`) and use ISO format with `Z` suffix instead of TZID format when building the RRULE string. This ensures rrule.js correctly interprets the time as UTC.

**Changed behavior:**
- Before: `FREQ=DAILY;COUNT=3;DTSTART;TZID=Etc/UTC:20240101T100000` (no Z, interpreted as local)
- After: `FREQ=DAILY;COUNT=3;DTSTART=20240101T100000Z` (with Z, interpreted as UTC)

## Verification

- All 65 tests passing
- Updated snapshot: `test/snapshots/example-rrule-basic.txt` now shows correct `10:00` instead of `11:00`
- Verified with `examples/example-rrule-basic.js`

## Minimal script to reproduce/test

```js
// Tiny VCALENDAR with DTSTART in UTC and a daily RRULE
const icsContent = `BEGIN:VCALENDAR
VERSION:2.0
BEGIN:VEVENT
DTSTART:20240101T100000Z
DTEND:20240101T110000Z
RRULE:FREQ=DAILY;COUNT=3
END:VEVENT
END:VCALENDAR`;

// Parse and find VEVENT
const data = ical.parseICS(icsContent);
const event = Object.values(data).find(item => item.type === 'VEVENT');

// Expand RRULE over January 2024 (inclusive)
const occurrences = event.rrule.between(
  new Date('2024-01-01T00:00:00Z'),
  new Date('2024-01-31T23:59:59Z'),
  true
);

// Verify first occurrence is 10:00 UTC (not 11:00)
const firstHour = occurrences[0].getUTCHours();
console.log(firstHour === 10 ? '✅ FIXED' : '❌ BROKEN');
```

## Is this a new bug?

My investigation revealed this UTC time shift bug existed **since at least v0.20.0**:

- v0.20.0: ❌ BROKEN
- v0.21.0: ❌ BROKEN
- v0.22.0: ❌ BROKEN

The bug was **not** introduced by the moment-timezone → Intl refactoring :sweat_smile: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTC timezone handling for calendar events so recurring events and DTSTART values are no longer incorrectly converted and now display correct times.

* **Tests**
  * Added unit tests to validate UTC timezone detection and updated snapshots to reflect corrected event times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->