### PR TITLE
fix: add missing WR-CALDESC prop to VCALENDAR type

### DIFF
--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -162,6 +162,7 @@ declare module 'node-ical' {
     calscale?: 'GREGORIAN' | string;
     method?: Method;
     'WR-CALNAME'?: string;
+    'WR-CALDESC'?: string;
     'WR-TIMEZONE'?: string;
   } & BaseComponent;
 


### PR DESCRIPTION
I see both WR-CALNAME and WR-CALDESC when I console.log() the VCALENDAR object at runtime, but the type for WR-CALDESC was missing.

This PR adds the missing prop to the VCalendar typescript type.

- Related to https://github.com/jens-maus/node-ical/issues/141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calendar description property (WR-CALDESC), allowing access to calendar metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->