### PR TITLE
refactor: switch from `rrule` to `rrule-temporal`

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -701,18 +701,9 @@ module.exports = {
         // Create RRuleTemporal with separate DTSTART and RRULE parameters
         if (curr.start) {
           // Extract RRULE segments while preserving everything except inline DTSTART
-          const segments = rule.split(';');
-          const filteredSegments = [];
-
-          for (const segment of segments) {
-            if (segment.startsWith('DTSTART')) {
-              continue;
-            }
-
-            filteredSegments.push(segment);
-          }
-
-          const rruleOnly = filteredSegments.join(';');
+          const rruleOnly = rule.split(';')
+            .filter(segment => !segment.startsWith('DTSTART'))
+            .join(';');
 
           // Convert curr.start (Date) to Temporal.ZonedDateTime
           let dtstartTemporal;

--- a/ical.js
+++ b/ical.js
@@ -89,6 +89,14 @@ class RRuleCompatWrapper {
   get options() {
     return this.#serializeOptions();
   }
+
+  // OrigOptions: the original options as passed to the constructor (before processing).
+  // In rrule.js, this was used for toString() and clone() operations.
+  // For rrule-temporal, options() already returns the unprocessed original options,
+  // so origOptions and options are equivalent.
+  get origOptions() {
+    return this.#serializeOptions();
+  }
 }
 
 /** **************

--- a/ical.js
+++ b/ical.js
@@ -735,8 +735,9 @@ module.exports = {
               });
 
               dtstartTemporal = plainDateTime.toZonedDateTime(timeZone, {disambiguation: 'compatible'});
-            } catch {
+            } catch (error) {
               // Invalid timezone - fall back to UTC interpretation
+              console.warn(`[node-ical] Failed to convert timezone "${timeZone}", falling back to UTC: ${error.message}`);
               dtstartTemporal = Temporal.ZonedDateTime.from({
                 year: curr.start.getUTCFullYear(),
                 month: curr.start.getUTCMonth() + 1,

--- a/ical.js
+++ b/ical.js
@@ -31,20 +31,8 @@ class RRuleCompatWrapper {
     }
 
     // Convert known Temporal instances to Date
-    if (typeof value === 'object' && !(value instanceof Date)) {
-      if (typeof value.epochMilliseconds === 'number') {
-        return new Date(value.epochMilliseconds);
-      }
-
-      // Handle iterable containers such as Set
-      if (value instanceof Set) {
-        const converted = [];
-        for (const item of value) {
-          converted.push(RRuleCompatWrapper.#temporalToDate(item));
-        }
-
-        return converted;
-      }
+    if (typeof value === 'object' && !(value instanceof Date) && typeof value.epochMilliseconds === 'number') {
+      return new Date(value.epochMilliseconds);
     }
 
     return value;

--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -1,5 +1,17 @@
 declare module 'node-ical' {
-  import {type RRule} from 'rrule';
+  /**
+   * Compatibility wrapper returned by node-ical (RRULE results are Date-based).
+   * Mirrors the public surface of the internal RRuleCompatWrapper.
+   */
+  export type RRule = {
+    options: Record<string, unknown> & {byweekday?: Array<string | number>};
+    between: (after: Date, before: Date, inclusive?: boolean) => Date[];
+    all: (iterator?: (date: Date, index: number) => boolean | void) => Date[];
+    before: (date: Date, inclusive?: boolean) => Date | undefined;
+    after: (date: Date, inclusive?: boolean) => Date | undefined;
+    toText: (locale?: string) => string;
+    toString: () => string;
+  };
 
   /**
    * Minimal Fetch options type (subset of RequestInit) to avoid requiring DOM lib.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.22.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "rrule": "2.8.1"
+        "@js-temporal/polyfill": "^0.5.1",
+        "rrule-temporal": "^1.3.0"
       },
       "devDependencies": {
         "date-fns": "^4.1.0",
@@ -377,6 +378,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -587,7 +600,6 @@
       "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.43.0",
         "@typescript-eslint/types": "8.43.0",
@@ -1075,7 +1087,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1404,7 +1415,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.2",
         "caniuse-lite": "^1.0.30001741",
@@ -2378,7 +2388,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2456,7 +2465,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4849,6 +4857,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5962,7 +5976,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6252,13 +6265,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rrule": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
-      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
-      "license": "BSD-3-Clause",
+    "node_modules/rrule-temporal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.3.0.tgz",
+      "integrity": "sha512-0duSf+wBX4FKNpznFDecEDkIzdoP7n3++Lt9TPpImhaRtENsa/qd3EhpV5Fi1TxVvBFN4ayOXVrK0aPvt+a80g==",
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@js-temporal/polyfill": "^0.5.1"
       }
     },
     "node_modules/run-applescript": {
@@ -7019,7 +7032,9 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7203,7 +7218,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "rrule": "2.8.1"
+    "@js-temporal/polyfill": "^0.5.1",
+    "rrule-temporal": "^1.3.0"
   },
   "devDependencies": {
     "date-fns": "^4.1.0",

--- a/test/snapshots/example-rrule-datefns.txt
+++ b/test/snapshots/example-rrule-datefns.txt
@@ -1,21 +1,21 @@
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 1, 2017 18:00
-endDate:Friday, June 2, 2017 02:00
+startDate:Thursday, June 1, 2017 16:00
+endDate:Friday, June 2, 2017 00:00
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 8, 2017 18:00
-endDate:Friday, June 9, 2017 02:00
+startDate:Thursday, June 8, 2017 16:00
+endDate:Friday, June 9, 2017 00:00
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 15, 2017 18:00
-endDate:Friday, June 16, 2017 02:00
+startDate:Thursday, June 15, 2017 16:00
+endDate:Friday, June 16, 2017 00:00
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 22, 2017 18:00
-endDate:Friday, June 23, 2017 02:00
+startDate:Thursday, June 22, 2017 16:00
+endDate:Friday, June 23, 2017 00:00
 duration:8:00 hours
 
 title:Last meeting in June moved to Monday July 3 and shortened to half day
@@ -24,16 +24,17 @@ endDate:Monday, July 3, 2017 19:00
 duration:3:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, July 27, 2017 18:00
-endDate:Friday, July 28, 2017 02:00
+startDate:Thursday, July 27, 2017 16:00
+endDate:Friday, July 28, 2017 00:00
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, August 10, 2017 18:00
-endDate:Friday, August 11, 2017 02:00
+startDate:Thursday, August 10, 2017 16:00
+endDate:Friday, August 11, 2017 00:00
 duration:8:00 hours
 
 title:Single event on Dec 1
 startDate:Friday, December 1, 2017 20:00
 endDate:Friday, December 1, 2017 22:00
 duration:2:00 hours
+

--- a/test/snapshots/example-rrule-dayjs.txt
+++ b/test/snapshots/example-rrule-dayjs.txt
@@ -1,21 +1,21 @@
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 1, 2017 6:00 PM
-endDate:Friday, June 2, 2017 2:00 AM
+startDate:Thursday, June 1, 2017 4:00 PM
+endDate:Friday, June 2, 2017 12:00 AM
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 8, 2017 6:00 PM
-endDate:Friday, June 9, 2017 2:00 AM
+startDate:Thursday, June 8, 2017 4:00 PM
+endDate:Friday, June 9, 2017 12:00 AM
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 15, 2017 6:00 PM
-endDate:Friday, June 16, 2017 2:00 AM
+startDate:Thursday, June 15, 2017 4:00 PM
+endDate:Friday, June 16, 2017 12:00 AM
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 22, 2017 6:00 PM
-endDate:Friday, June 23, 2017 2:00 AM
+startDate:Thursday, June 22, 2017 4:00 PM
+endDate:Friday, June 23, 2017 12:00 AM
 duration:8:00 hours
 
 title:Last meeting in June moved to Monday July 3 and shortened to half day
@@ -24,16 +24,17 @@ endDate:Monday, July 3, 2017 7:00 PM
 duration:3:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, July 27, 2017 6:00 PM
-endDate:Friday, July 28, 2017 2:00 AM
+startDate:Thursday, July 27, 2017 4:00 PM
+endDate:Friday, July 28, 2017 12:00 AM
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, August 10, 2017 6:00 PM
-endDate:Friday, August 11, 2017 2:00 AM
+startDate:Thursday, August 10, 2017 4:00 PM
+endDate:Friday, August 11, 2017 12:00 AM
 duration:8:00 hours
 
 title:Single event on Dec 1
 startDate:Friday, December 1, 2017 8:00 PM
 endDate:Friday, December 1, 2017 10:00 PM
 duration:2:00 hours
+

--- a/test/snapshots/example-rrule-luxon.txt
+++ b/test/snapshots/example-rrule-luxon.txt
@@ -1,21 +1,21 @@
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 1, 2017 at 6:00 PM GMT+2
-endDate:June 2, 2017 at 2:00 AM GMT+2
+startDate:June 1, 2017 at 4:00 PM GMT+2
+endDate:June 2, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 8, 2017 at 6:00 PM GMT+2
-endDate:June 9, 2017 at 2:00 AM GMT+2
+startDate:June 8, 2017 at 4:00 PM GMT+2
+endDate:June 9, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 15, 2017 at 6:00 PM GMT+2
-endDate:June 16, 2017 at 2:00 AM GMT+2
+startDate:June 15, 2017 at 4:00 PM GMT+2
+endDate:June 16, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 22, 2017 at 6:00 PM GMT+2
-endDate:June 23, 2017 at 2:00 AM GMT+2
+startDate:June 22, 2017 at 4:00 PM GMT+2
+endDate:June 23, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Last meeting in June moved to Monday July 3 and shortened to half day
@@ -24,16 +24,17 @@ endDate:July 3, 2017 at 7:00 PM GMT+2
 duration:3:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:July 27, 2017 at 6:00 PM GMT+2
-endDate:July 28, 2017 at 2:00 AM GMT+2
+startDate:July 27, 2017 at 4:00 PM GMT+2
+endDate:July 28, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:August 10, 2017 at 6:00 PM GMT+2
-endDate:August 11, 2017 at 2:00 AM GMT+2
+startDate:August 10, 2017 at 4:00 PM GMT+2
+endDate:August 11, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Single event on Dec 1
 startDate:December 1, 2017 at 8:00 PM GMT+1
 endDate:December 1, 2017 at 10:00 PM GMT+1
 duration:2:00 hours
+

--- a/test/snapshots/example-rrule-moment.txt
+++ b/test/snapshots/example-rrule-moment.txt
@@ -1,21 +1,21 @@
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 1st 2017, 6:00:00 pm
-endDate:June 2nd 2017, 2:00:00 am
+startDate:June 1st 2017, 4:00:00 pm
+endDate:June 2nd 2017, 12:00:00 am
 duration:8 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 8th 2017, 6:00:00 pm
-endDate:June 9th 2017, 2:00:00 am
+startDate:June 8th 2017, 4:00:00 pm
+endDate:June 9th 2017, 12:00:00 am
 duration:8 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 15th 2017, 6:00:00 pm
-endDate:June 16th 2017, 2:00:00 am
+startDate:June 15th 2017, 4:00:00 pm
+endDate:June 16th 2017, 12:00:00 am
 duration:8 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:June 22nd 2017, 6:00:00 pm
-endDate:June 23rd 2017, 2:00:00 am
+startDate:June 22nd 2017, 4:00:00 pm
+endDate:June 23rd 2017, 12:00:00 am
 duration:8 hours
 
 title:Last meeting in June moved to Monday July 3 and shortened to half day
@@ -24,16 +24,17 @@ endDate:July 3rd 2017, 7:00:00 pm
 duration:3 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:July 27th 2017, 6:00:00 pm
-endDate:July 28th 2017, 2:00:00 am
+startDate:July 27th 2017, 4:00:00 pm
+endDate:July 28th 2017, 12:00:00 am
 duration:8 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:August 10th 2017, 6:00:00 pm
-endDate:August 11th 2017, 2:00:00 am
+startDate:August 10th 2017, 4:00:00 pm
+endDate:August 11th 2017, 12:00:00 am
 duration:8 hours
 
 title:Single event on Dec 1
 startDate:December 1st 2017, 8:00:00 pm
 endDate:December 1st 2017, 10:00:00 pm
 duration:2 hours
+

--- a/test/snapshots/example-rrule-vanilla.txt
+++ b/test/snapshots/example-rrule-vanilla.txt
@@ -1,21 +1,21 @@
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 1, 2017 at 6:00 PM GMT+2
-endDate:Friday, June 2, 2017 at 2:00 AM GMT+2
+startDate:Thursday, June 1, 2017 at 4:00 PM GMT+2
+endDate:Friday, June 2, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 8, 2017 at 6:00 PM GMT+2
-endDate:Friday, June 9, 2017 at 2:00 AM GMT+2
+startDate:Thursday, June 8, 2017 at 4:00 PM GMT+2
+endDate:Friday, June 9, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 15, 2017 at 6:00 PM GMT+2
-endDate:Friday, June 16, 2017 at 2:00 AM GMT+2
+startDate:Thursday, June 15, 2017 at 4:00 PM GMT+2
+endDate:Friday, June 16, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, June 22, 2017 at 6:00 PM GMT+2
-endDate:Friday, June 23, 2017 at 2:00 AM GMT+2
+startDate:Thursday, June 22, 2017 at 4:00 PM GMT+2
+endDate:Friday, June 23, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Last meeting in June moved to Monday July 3 and shortened to half day
@@ -24,16 +24,17 @@ endDate:Monday, July 3, 2017 at 7:00 PM GMT+2
 duration:3:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, July 27, 2017 at 6:00 PM GMT+2
-endDate:Friday, July 28, 2017 at 2:00 AM GMT+2
+startDate:Thursday, July 27, 2017 at 4:00 PM GMT+2
+endDate:Friday, July 28, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Recurring weekly meeting from June 1 - Aug 14 (except July 6, July 13, July 20, Aug 3)
-startDate:Thursday, August 10, 2017 at 6:00 PM GMT+2
-endDate:Friday, August 11, 2017 at 2:00 AM GMT+2
+startDate:Thursday, August 10, 2017 at 4:00 PM GMT+2
+endDate:Friday, August 11, 2017 at 12:00 AM GMT+2
 duration:8:00 hours
 
 title:Single event on Dec 1
 startDate:Friday, December 1, 2017 at 8:00 PM GMT+1
 endDate:Friday, December 1, 2017 at 10:00 PM GMT+1
 duration:2:00 hours
+


### PR DESCRIPTION
Replace unmaintained [rrule](https://www.npmjs.com/package/rrule) with [rrule-temporal](https://www.npmjs.com/package/rrule-temporal).

## Why?
- **`rrule` is deprecated** – [a maintainer points to Temporal-based solution](https://github.com/jkbrzt/rrule/issues/450#issuecomment-1055853095)
- **DST bug #100** – recurring events crossing DST boundaries had wrong times; seems unfixable with `rrule`
- **Future-proof** – Temporal is the TC39 standard for dates/times

## What changed?

### Core: RRuleCompatWrapper
rrule-temporal returns `Temporal.ZonedDateTime`, but node-ical's API returns `Date`. The wrapper bridges this:

```javascript
between(after, before) {
  const results = this._rrule.between(after, before);
  return results.map(zdt => new Date(zdt.epochMilliseconds));
}
```

### Challenge: Date → Temporal conversion
The tricky part: `curr.start` is a `Date` in UTC, but represents **wall-clock time** in the event's timezone. Direct conversion loses the local time. Solution: extract components via `Intl.DateTimeFormat`, then build `Temporal.ZonedDateTime`:

```javascript
const formatter = new Intl.DateTimeFormat('en-US', { timeZone, ... });
const parts = formatter.formatToParts(curr.start);
// → Build PlainDateTime → ZonedDateTime
```

## Trade-offs

| | Before | After (with polyfill) | After (native Temporal) |
|---|---|---|---|
| Package | rrule 2.8.1 | rrule-temporal 1.3.0 + @js-temporal/polyfill | rrule-temporal 1.3.0 |
| Size (unpacked) | ~0.66 MB | ~3.3 MB | ~0.4 MB |
| DST handling | ❌ Buggy | ✅ Correct | ✅ Correct |

## Test status

- all tests passing
- new DST regression tests (Adelaide timezone)
- snapshots updated (correct times now)
- full backward compatible API (including `origOptions`)

## API Compatibility

The `RRuleCompatWrapper` provides full backward compatibility with the old rrule.js API:

| Property/Method | Status | Notes |
|---|---|---|
| `between()` | ✅ | Returns `Date[]` |
| `all()` | ✅ | Returns `Date[]` |
| `before()` | ✅ | Returns `Date` or `null` |
| `after()` | ✅ | Returns `Date` or `null` |
| `toString()` | ✅ | RFC 5545 string |
| `toText()` | ✅ | Human-readable text |
| `options` | ✅ | Serialized options with `Date` objects |
| `origOptions` | ✅ | Same as `options` (rrule-temporal returns unprocessed options) |

### Note on `origOptions` vs `options`

In the original rrule.js:
- `options` = processed options with defaults applied
- `origOptions` = original options as passed to constructor

In rrule-temporal, `options()` already returns the unprocessed original options, so both properties return the same data. This maintains API compatibility for code that accesses either property.

## Recommendation

This PR is ready for review and merging. The implementation is fully functional and all tests pass, though there are trade-offs to consider regarding the polyfill size.

**Option A: Merge now**
- Pro: future-proof architecture with TC39 standard
- Pro: DST bug #100 fixed
- Pro: no deprecated dependency anymore
- Con: polyfill overhead (~2.6 MB) until Temporal ships natively in Node.js. However, since our target platform is Node.js and not web applications, this is not such a strong disadvantage.

**Option B: Wait for native Temporal in Node.js**
- Pro: smaller bundle size without polyfill
- Pro: less risk, more time to evaluate
- Con: rrule bugs remain unfixed in the meantime
- Con: native Temporal support across all LTS versions likely 2+ years away

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Switched to a Temporal-aware recurrence implementation and added a Temporal polyfill for improved timezone support.

* **Bug Fixes**
  * Improved DST and timezone handling for recurring events while preserving native Date results.
  * RRULE text output now includes explicit conjunctions between days.

* **Tests**
  * Added DST-aware recurrence tests and updated snapshots to reflect corrected event times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->