### PR TITLE
fix(parser): change exdate from array to plain object

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -276,7 +276,7 @@ const categoriesParameter = function (name) {
 // EXDATE is an entry that represents exceptions to a recurrence rule (ex: "repeat every day except on 7/4").
 // The EXDATE entry itself can also contain a comma-separated list, so we make sure to parse each date out separately.
 // There can also be more than one EXDATE entries in a calendar record.
-// Since there can be multiple dates, we create an array of them.  The index into the array is the ISO string of the date itself, for ease of use.
+// Since there can be multiple dates, we create an object of them.  The key is the ISO date string (YYYY-MM-DD) and the value is the Date object, for ease of use.
 // i.e. You can check if ((curr.exdate != undefined) && (curr.exdate[date iso string] != undefined)) to see if a date is an exception.
 // NOTE: This specifically uses date only, and not time.  This is to avoid a few problems:
 //    1. The ISO string with time wouldn't work for "floating dates" (dates without timezones).
@@ -291,7 +291,7 @@ const categoriesParameter = function (name) {
 // TODO: See if this causes any problems with events that recur multiple times a day.
 const exdateParameter = function (name) {
   return function (value, parameters, curr) {
-    curr[name] ||= [];
+    curr[name] ||= {};
     const dates = value ? value.split(',').map(s => s.trim()) : [];
     for (const entry of dates) {
       const exdate = [];


### PR DESCRIPTION
EXDATE was previously initialized as an array ([]) but used as an object with date-string keys, creating a confusing "array with object properties" anti-pattern. This caused several issues:

- JSON.stringify(event.exdate) showed [] instead of the actual dates
- event.exdate.length was 0 despite containing exception dates
- Array methods (.map, .filter, etc.) didn't work as expected
- Violated JavaScript principle of least surprise

Changes:
- Initialize exdate as {} instead of []
- Update comment from "array" to "object" with clearer description
- Add regression tests for issues #167 and #360

The documented usage pattern (event.exdate[dateKey]) continues to work exactly as before, and all existing workarounds remain functional.

BREAKING CHANGE: exdate is now a plain object instead of an array
- Array.isArray(event.exdate) returns false (was true)
- event.exdate.length is undefined (was 0)
- Array iteration methods no longer apply (but never worked correctly)

These breaking changes only affect code that was already broken due to the array-object hybrid pattern.

Fixes #167
Fixes #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced EXDATE (excluded dates) handling to ensure recurring calendar events properly exclude specified dates from recurrence patterns.

* **Tests**
  * Added comprehensive test coverage for EXDATE functionality, including comma-separated dates, edge cases, and regression scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->