### PR TITLE
fix: handle malformed DURATION values gracefully

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -519,45 +519,67 @@ module.exports = {
         const par = stack.pop();
 
         if (!curr.end) { // RFC5545, 3.6.1
-          // Set the end according to the datetype of event
-          curr.end = (curr.datetype === 'date-time') ? new Date(curr.start) : tzUtil.utcAdd(curr.start, 1, 'days');
+          // Helper: clone a Date and preserve custom metadata (tz, dateOnly)
+          const cloneDateWithMeta = (source, newTime = source) => {
+            const cloned = new Date(newTime);
+            if (source?.tz) {
+              cloned.tz = source.tz;
+            }
 
-          // If there was a duration specified
-          // see RFC5545, 3.3.6 (no year and month)
-          if (curr.duration !== undefined) {
-            const durationUnits
-            = {
-              W: 'weeks',
-              D: 'days',
-              H: 'hours',
-              M: 'minutes',
-              S: 'seconds',
-            };
-            // Get the list of duration elements
-            const duration = curr.duration.match(/-?\d{1,10}[WDHMS]/g);
-            if (!duration || duration.length === 0) {
-              // Invalid or empty DURATION: treat as zero duration (end = start)
-              // This handles malformed cases like "DURATION:P" gracefully (Postel's Law)
-              console.warn(`[node-ical] Ignoring malformed DURATION value: "${curr.duration}" – treating as zero duration`);
-              curr.end = curr.start;
-            } else {
-              // Use the duration to create the end value, from the start
-              let newEnd = curr.start;
+            if (source?.dateOnly) {
+              cloned.dateOnly = source.dateOnly;
+            }
 
-              // Is the 1st character a negative sign?
-              const indicator = curr.duration.startsWith('-') ? -1 : 1;
+            return cloned;
+          };
 
-              for (const r of duration) {
-                const unit = r.slice(-1);
-                if (!durationUnits[unit]) {
-                  throw new Error(`Invalid duration unit: ${unit}`);
-                }
+          // Helper: extract string value from DURATION (handles {params, val} shape)
+          const getDurationString = duration => {
+            if (typeof duration === 'object' && duration?.val) {
+              return String(duration.val);
+            }
 
-                newEnd = tzUtil.utcAdd(newEnd, Number.parseInt(r, 10) * indicator, durationUnits[r.toString().slice(-1)]);
+            if (duration) {
+              return String(duration);
+            }
+
+            return '';
+          };
+
+          // Calculate end date based on DURATION or default rules
+          if (curr.duration === undefined) {
+            // No DURATION: default end is same time (date-time) or +1 day (date-only)
+            curr.end = curr.datetype === 'date-time'
+              ? cloneDateWithMeta(curr.start)
+              : cloneDateWithMeta(curr.start, tzUtil.utcAdd(curr.start, 1, 'days'));
+          } else {
+            const durationString = getDurationString(curr.duration);
+            const durationParts = durationString.match(/-?\d{1,10}[WDHMS]/g);
+
+            if (durationParts && durationParts.length > 0) {
+              // Valid DURATION: apply each component (W/D/H/M/S)
+              const units = {
+                W: 'weeks',
+                D: 'days',
+                H: 'hours',
+                M: 'minutes',
+                S: 'seconds',
+              };
+              const sign = durationString.startsWith('-') ? -1 : 1;
+
+              let endTime = curr.start;
+              for (const part of durationParts) {
+                const value = Number.parseInt(part, 10) * sign;
+                const unit = units[part.slice(-1)];
+                endTime = tzUtil.utcAdd(endTime, value, unit);
               }
 
-              // End is a Date type, not moment
-              curr.end = new Date(newEnd);
+              curr.end = cloneDateWithMeta(curr.start, endTime);
+            } else {
+              // Malformed DURATION (e.g., "P", "PT", "") → treat as zero duration
+              // Follows Postel's Law: be liberal in what you accept
+              console.warn(`[node-ical] Ignoring malformed DURATION value: "${durationString}" – treating as zero duration`);
+              curr.end = cloneDateWithMeta(curr.start);
             }
           }
         }

--- a/test/advanced.test.js
+++ b/test/advanced.test.js
@@ -436,6 +436,30 @@ END:VCALENDAR`;
       assert.equal(event.end.toDateString(), new Date(2024, 1, 22).toDateString());
     });
 
+    // Test parameterized DURATION (shape-safety)
+    it('handles parameterized DURATION values', () => {
+      const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:parameterized-duration-test
+DTSTART:20250101T120000Z
+DURATION;X-CUSTOM=foo:P1D
+SUMMARY:Test Parameterized Duration
+END:VEVENT
+END:VCALENDAR`;
+
+      const data = ical.parseICS(ics);
+      const event = Object.values(data).find(x => x.type === 'VEVENT');
+
+      assert.ok(event, 'Event should be parsed');
+      assert.ok(event.start instanceof Date, 'Start should be a Date');
+      assert.ok(event.end instanceof Date, 'End should be a Date');
+
+      // Should add 1 day despite having parameters
+      const expectedEnd = new Date(event.start.getTime() + (24 * 60 * 60 * 1000));
+      assert.equal(event.end.toISOString(), expectedEnd.toISOString());
+    });
+
     // Issue #381 – empty DURATION:P should not crash
     it('handles empty duration DURATION:P gracefully (issue #381)', () => {
       const ics = `BEGIN:VCALENDAR

--- a/test/advanced.test.js
+++ b/test/advanced.test.js
@@ -455,6 +455,10 @@ END:VCALENDAR`;
       // Instead: treat empty/invalid duration as zero duration (end = start)
       // This follows Postel's Law: "be liberal in what you accept"
 
+      // Stub console.warn to keep test output clean
+      const originalWarn = console.warn;
+      console.warn = () => {};
+
       const data = ical.parseICS(ics);
       const event = Object.values(data).find(x => x.type === 'VEVENT');
 
@@ -469,10 +473,17 @@ END:VCALENDAR`;
         event.start.toISOString(),
         'End should equal start for invalid DURATION:P (zero duration)',
       );
+
+      // Restore console.warn
+      console.warn = originalWarn;
     });
 
     // Additional test: Multiple invalid duration formats should be handled
     it('handles various malformed DURATION values gracefully', () => {
+      // Stub console.warn to keep test output clean
+      const originalWarn = console.warn;
+      console.warn = () => {};
+
       const testCases = [
         // Malformed / invalid durations → should be treated as zero duration
         {duration: 'P', summary: 'Empty P', expected: 'zero'},
@@ -488,11 +499,11 @@ END:VCALENDAR`;
         {duration: 'P1DT2H', summary: 'One day two hours', expected: '1d2h'}, // Day + hours
       ];
 
-      for (const testCase of testCases) {
+      for (const [i, testCase] of testCases.entries()) {
         const ics = `BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
-UID:malformed-${testCase.summary}
+UID:malformed-${i}
 DTSTART:20250706T160000Z
 DURATION:${testCase.duration}
 SUMMARY:${testCase.summary}
@@ -567,6 +578,9 @@ END:VCALENDAR`;
           }
         }
       }
+
+      // Restore console.warn
+      console.warn = originalWarn;
     });
   });
 


### PR DESCRIPTION
Fixes parser crash when encountering invalid DURATION values like "DURATION:P". Following Postel's Law (be liberal in what you accept), malformed DURATION values are now treated as zero duration (end = start) with a warning logged.

Changes:
- Treat empty/malformed DURATION as zero duration instead of throwing error
- Add console.warn() for developer visibility when malformed values encountered
- Add comprehensive test coverage (10 edge cases) including:
  * Malformed values: P, PT, INVALID, empty string
  * Valid zero durations: PT0S, P0D
  * Positive/negative durations: P1D, -P1D
  * Combined durations: PT1H30M, P1DT2H

This prevents crashes in real-world calendars containing non-RFC5545 compliant DURATION values while alerting developers to data quality issues.

Fixes #381.

## Additional Improvements

Based on code review feedback, this PR also includes:

- **Shape-safety**: Handle parameterized DURATION values (e.g., `DURATION;X-CUSTOM=foo:P1D`) 
  that are stored as `{params, val}` objects instead of strings
- **Metadata preservation**: Fix loss of timezone (`tz`) and date-only (`dateOnly`) 
  metadata when calculating end dates. Previously, default end dates (when no DURATION 
  was present) would lose these properties.
- **Code quality**: Extract helper functions (`cloneDateWithMeta`, `getDurationString`) 
  to eliminate code duplication and improve maintainability

These improvements fix latent bugs that existed before but were rarely triggered in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DURATION parsing robustness—invalid or empty duration values now default to zero duration instead of crashing the parser, with improved warning logging.
  * Added support for negative duration indicators in event duration calculations.

* **Tests**
  * Added comprehensive test suite for DURATION parsing, validating behavior for malformed values, edge cases, and combined duration calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->