### PR TITLE
fix: preserve VALUE=DATE in DTSTART for RRULE parsing

### DIFF
--- a/test/date-only-rrule-until.test.js
+++ b/test/date-only-rrule-until.test.js
@@ -1,0 +1,111 @@
+/* eslint-env mocha */
+/* eslint-disable prefer-arrow-callback */
+
+const assert = require('node:assert/strict');
+const {describe, it} = require('mocha');
+const ical = require('../node-ical.js');
+
+describe('DATE-only RRULE with UNTIL (regression test for Google Calendar birthday events)', function () {
+  it('should parse DATE-only events with yearly RRULE and UNTIL in the past', function () {
+    // This is the exact format that Google Calendar uses for birthday events
+    // that caused the bug report in MagicMirror PR #4016
+    const icsData = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20160313
+DTEND;VALUE=DATE:20160314
+RRULE:FREQ=YEARLY;UNTIL=20190312;BYMONTHDAY=13;BYMONTH=3
+DTSTAMP:20260122T223427Z
+UID:test-birthday-event
+SUMMARY:Birthday Event
+TRANSP:OPAQUE
+END:VEVENT
+END:VCALENDAR`;
+
+    // Should parse without throwing "UNTIL rule part MUST have the same value type as DTSTART"
+    const parsed = ical.parseICS(icsData);
+    const event = Object.values(parsed).find(event_ => event_.type === 'VEVENT');
+
+    assert.ok(event, 'Event should be defined');
+    assert.strictEqual(event.summary, 'Birthday Event');
+    assert.strictEqual(event.start.dateOnly, true, 'Start should be date-only');
+    assert.ok(event.rrule, 'RRULE should be defined');
+
+    // Should not throw when accessing rrule
+    assert.doesNotThrow(() => event.rrule.toString());
+
+    // Generate recurrences
+    const recurrences = event.rrule.all();
+    assert.ok(recurrences.length > 0, 'Should have recurrences');
+
+    // Should have exactly 3 occurrences (2016, 2017, 2018)
+    // UNTIL=20190312 means up to and including 2018-03-13 (not 2019-03-13)
+    assert.strictEqual(recurrences.length, 3, 'Should have 3 occurrences');
+
+    // First occurrence should be on 2016-03-13
+    const firstDate = new Date(recurrences[0]);
+    assert.strictEqual(firstDate.getUTCFullYear(), 2016);
+    assert.strictEqual(firstDate.getUTCMonth(), 2); // March (0-indexed)
+    assert.strictEqual(firstDate.getUTCDate(), 13);
+
+    // Last occurrence should be on 2018-03-13
+    const lastDate = new Date(recurrences.at(-1));
+    assert.strictEqual(lastDate.getUTCFullYear(), 2018);
+    assert.strictEqual(lastDate.getUTCMonth(), 2);
+    assert.strictEqual(lastDate.getUTCDate(), 13);
+  });
+
+  it('should preserve VALUE=DATE in DTSTART when creating RRULE string', function () {
+    const icsData = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20200101
+DTEND;VALUE=DATE:20200102
+RRULE:FREQ=MONTHLY;UNTIL=20201231;BYMONTHDAY=1
+UID:test-monthly-event
+SUMMARY:Monthly Event
+END:VEVENT
+END:VCALENDAR`;
+
+    const parsed = ical.parseICS(icsData);
+    const event = Object.values(parsed).find(event_ => event_.type === 'VEVENT');
+
+    assert.ok(event, 'Event should be defined');
+    assert.strictEqual(event.start.dateOnly, true, 'Start should be date-only');
+    assert.ok(event.rrule, 'RRULE should be defined');
+
+    // The internal RRULE string should include VALUE=DATE
+    const rruleString = event.rrule.toString();
+    assert.ok(rruleString, 'RRULE string should be defined');
+
+    // Generate recurrences
+    const recurrences = event.rrule.all();
+    assert.strictEqual(recurrences.length, 12, 'Should have 12 monthly occurrences');
+  });
+
+  it('should handle DATE-only RRULE without UNTIL', function () {
+    const icsData = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20200101
+DTEND;VALUE=DATE:20200102
+RRULE:FREQ=YEARLY;COUNT=5;BYMONTH=1;BYMONTHDAY=1
+UID:test-yearly-event
+SUMMARY:New Year's Day
+END:VEVENT
+END:VCALENDAR`;
+
+    const parsed = ical.parseICS(icsData);
+    const event = Object.values(parsed).find(event_ => event_.type === 'VEVENT');
+
+    assert.ok(event, 'Event should be defined');
+    assert.strictEqual(event.start.dateOnly, true, 'Start should be date-only');
+    assert.ok(event.rrule, 'RRULE should be defined');
+
+    const recurrences = event.rrule.all();
+    assert.strictEqual(recurrences.length, 5, 'Should have 5 occurrences');
+  });
+});


### PR DESCRIPTION
## Problem

When parsing recurring all-day events (`VALUE=DATE`), the date-only information was never passed to the RRULE library. This became visible when `rrule-temporal` yesterday added strict RFC 5545 validation (with [v1.4.2](https://github.com/ggaabe/rrule-temporal/releases/tag/v1.4.2)), causing it to reject DATE-only UNTIL values:

```
Error: UNTIL rule part MUST have the same value type as DTSTART
```

**Example:** Google Calendar birthday events
```ics
DTSTART;VALUE=DATE:20160313
RRULE:FREQ=YEARLY;UNTIL=20190312;BYMONTHDAY=13;BYMONTH=3
```

Both DTSTART and UNTIL are DATE values (correct per RFC 5545), but node-ical didn't preserve `VALUE=DATE` when passing to rrule-temporal, causing the validation to fail.

## Solution

Added check for `curr.start.dateOnly` to preserve the VALUE=DATE parameter.

Use local date components (not UTC) to stay consistent with how date-only events are parsed.

## Testing

- Yearly/monthly recurring DATE events with UNTIL
- DATE events with COUNT

## Impact

**Fixes:** Issue reported in [MagicMirrorOrg/MagicMirror#4016](https://github.com/MagicMirrorOrg/MagicMirror/pull/4016)

**Affected:** Users parsing recurring all-day events (birthdays, holidays) from Google Calendar and other CalDAV servers

**Breaking Changes:** None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date-only recurring events now preserve date-only semantics in recurrence rules and correctly handle UNTIL constraints without type errors, preventing incorrect validation or missing DTSTART behavior.

* **Tests**
  * Added end-to-end tests covering date-only recurring events with UNTIL, VALUE=DATE preservation, and COUNT-based recurrences to prevent regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->