### PR TITLE
fix(types): correct VEvent property types for iCalendar parameters

### DIFF
--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -128,8 +128,8 @@ declare module 'node-ical' {
     start: Date;
     /** End date/time of this instance */
     end: Date;
-    /** Event summary/title */
-    summary: string;
+    /** Event summary/title - copied from event, may include params */
+    summary: ParameterValue;
     /** Whether this is a full-day event (date-only, no time component) */
     isFullDay: boolean;
     /** Whether this instance came from a recurring rule */

--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -209,12 +209,15 @@ declare module 'node-ical' {
     sequence: string;
     transparency: Transparency;
     class: Class;
-    summary: string;
+    /** Event title/summary – may include params (e.g., LANGUAGE) */
+    summary: ParameterValue;
     start: DateWithTimeZone;
     datetype: DateType;
     end: DateWithTimeZone;
-    location: string;
-    description: string;
+    /** Event location – may include params (e.g., LANGUAGE, ALTREP) */
+    location: ParameterValue;
+    /** Event description – may include params (e.g., LANGUAGE, ALTREP) */
+    description: ParameterValue;
     url: string;
     completion: string;
     created: DateWithTimeZone;
@@ -293,18 +296,37 @@ declare module 'node-ical' {
     rdate: string | string[];
   };
 
-  type Property<A> = PropertyWithArgs<A> | string;
-
-  type PropertyWithArgs<A> = {
-    val: string;
-    params: A & Record<string, unknown>;
+  /**
+   * A property value that may include iCalendar parameters.
+   *
+   * When an iCalendar property has parameters (e.g., `SUMMARY;LANGUAGE=de:Restmuell`),
+   * node-ical returns an object with `params` and `val`. Without parameters, it returns
+   * the plain value directly.
+   *
+   * @example
+   * // Without parameters: string
+   * event.summary // => "Meeting"
+   *
+   * // With parameters: object
+   * event.summary // => { params: { LANGUAGE: "de" }, val: "Besprechung" }
+   *
+   * // Safe access pattern:
+   * const title = typeof event.summary === 'string'
+   *   ? event.summary
+   *   : event.summary?.val;
+   */
+  export type ParameterValue<T = string, P = Record<string, string>> = T | {
+    /** The actual property value */
+    val: T;
+    /** ICalendar parameters (e.g., LANGUAGE, ENCODING) */
+    params: P;
   };
 
-  export type Organizer = Property<{
+  export type Organizer = ParameterValue<string, {
     CN?: string;
   }>;
 
-  export type Attendee = Property<{
+  export type Attendee = ParameterValue<string, {
     CUTYPE?: AttendeeCUType;
     ROLE?: AttendeeRole;
     PARTSTAT?: AttendeePartStat;

--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -313,7 +313,7 @@ declare module 'node-ical' {
    * // Safe access pattern:
    * const title = typeof event.summary === 'string'
    *   ? event.summary
-   *   : event.summary?.val;
+   *   : event.summary.val;
    */
   export type ParameterValue<T = string, P = Record<string, string>> = T | {
     /** The actual property value */
@@ -323,16 +323,45 @@ declare module 'node-ical' {
   };
 
   export type Organizer = ParameterValue<string, {
+    /** Common Name - display name of the organizer */
     CN?: string;
+    /** Directory entry reference */
+    DIR?: string;
+    /** Sent by delegate */
+    'SENT-BY'?: string;
+    /** Language for text values */
+    LANGUAGE?: string;
+    /** Schedule agent */
+    'SCHEDULE-AGENT'?: string;
+    /** Allow additional parameters from parseParameters() */
+    [key: string]: string | undefined;
   }>;
 
   export type Attendee = ParameterValue<string, {
+    /** Calendar user type */
     CUTYPE?: AttendeeCUType;
+    /** Participation role */
     ROLE?: AttendeeRole;
+    /** Participation status */
     PARTSTAT?: AttendeePartStat;
+    /** RSVP expectation */
     RSVP?: boolean;
+    /** Common Name - display name of attendee */
     CN?: string;
+    /** Number of guests (non-standard) */
     'X-NUM-GUESTS'?: number;
+    /** Delegated to */
+    'DELEGATED-TO'?: string;
+    /** Delegated from */
+    'DELEGATED-FROM'?: string;
+    /** Group membership */
+    MEMBER?: string;
+    /** Directory entry reference */
+    DIR?: string;
+    /** Language for text values */
+    LANGUAGE?: string;
+    /** Allow additional parameters from parseParameters() */
+    [key: string]: string | number | boolean | undefined;
   }>;
 
   export type AttendeeCUType = 'INDIVIDUAL' | 'UNKNOWN' | 'GROUP' | 'ROOM' | string;


### PR DESCRIPTION
I took a look at the old issue #135 - the TypeScript declarations were indeed incorrect.

When iCalendar properties have parameters (e.g., `SUMMARY;LANGUAGE=de:Restmüll`), node-ical returns an object `{params, val}` instead of a plain string. The types declared them as `string`, which caused runtime type mismatches.

This PR introduces a `ParameterValue<T>` type for properties that can have parameters (summary, description, location) and extends Organizer/Attendee types with RFC 5545 optional parameters and index signatures for additional parsed parameters.

Fixes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event properties (summary, location, description) and participant fields (organizer, attendee) now support richer, parameterized values for more flexible metadata.
  * Public property types simplified in favor of a unified parameterized value model.
* **Documentation**
  * Added guidance and examples for the new parameterized value format, including safe-access patterns and handling of common parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->