### PR TITLE
refactor: clarify vcalendar handling and add TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ See the following example scripts for practical demonstration:
 
 Each library may display timezones differently, but the recurrence logic is the same.
 
+### TypeScript support
+
+node-ical includes full TypeScript type definitions. See [`examples/example-typescript.ts`](./examples/example-typescript.ts) for a complete example showing type-safe access to calendar properties, including the `vcalendar` object for accessing calendar-level metadata like `WR-CALNAME`.
+
 ## Under the hood
 
 **Windows/IANA time zones**: node-ical maps Windows time zone IDs and common legacy display-name labels to IANA via a generated `windowsZones.json`. It’s built from CLDR (`windowsZones.xml`) and augmented with legacy aliases for resilience; see `build/README.md` for details.

--- a/examples/example-typescript.ts
+++ b/examples/example-typescript.ts
@@ -1,0 +1,46 @@
+// TypeScript usage example demonstrating VCALENDAR metadata access
+
+import * as ical from 'node-ical';
+
+// Example: Parse Google Calendar
+const data = ical.sync.parseICS(`BEGIN:VCALENDAR
+PRODID:-//Google Inc//Google Calendar 70.9054//EN
+VERSION:2.0
+X-WR-CALNAME:node-ical test
+X-WR-TIMEZONE:Europe/Moscow
+X-WR-CALDESC:A simple calendar to test node-ical parser
+BEGIN:VEVENT
+DTSTART:20240101T100000Z
+DTEND:20240101T110000Z
+SUMMARY:Test Event
+UID:test-event-1
+END:VEVENT
+END:VCALENDAR`);
+
+// Access VCALENDAR properties via vcalendar object
+if (data.vcalendar) {
+  // TypeScript knows these properties exist!
+  const calendarName: string | undefined = data.vcalendar['WR-CALNAME'];
+  const timezone: string | undefined = data.vcalendar['WR-TIMEZONE'];
+  const description: string | undefined = data.vcalendar['WR-CALDESC'];
+  const {version} = data.vcalendar;
+  const {method} = data.vcalendar;
+
+  console.log('Calendar Name:', calendarName);
+  console.log('Timezone:', timezone);
+  console.log('Description:', description);
+  console.log('Version:', version);
+  console.log('Method:', method);
+}
+
+// Access events as before
+for (const uid in data) {
+  if (!Object.hasOwn(data, uid)) {
+    continue;
+  }
+
+  const component = data[uid];
+  if (component && typeof component === 'object' && 'type' in component && component.type === 'VEVENT') {
+    console.log('Event:', component.summary);
+  }
+}

--- a/ical.js
+++ b/ical.js
@@ -492,10 +492,12 @@ module.exports = {
       const originalEnd = function (component, parameters_, curr, stack) {
         // Prevents the need to search the root of the tree for the VCALENDAR object
         if (component === 'VCALENDAR') {
-          // Scan all high level object in curr and drop all strings
+          // Preserve VCALENDAR string properties in a separate 'vcalendar' object
+          // for easy access to calendar metadata
+          // (X-WR-CALNAME, X-WR-CALDESC, X-WR-TIMEZONE, METHOD, etc.)
           let key;
           let object;
-          const highLevel = {};
+          const vcalendarProps = {};
 
           for (key in curr) {
             if (!Object.hasOwn(curr, key)) {
@@ -504,13 +506,14 @@ module.exports = {
 
             object = curr[key];
             if (typeof object === 'string') {
-              highLevel[key] = object;
+              vcalendarProps[key] = object;
               delete curr[key];
             }
           }
 
-          if (highLevel.type) {
-            curr[highLevel.type.toLowerCase()] = highLevel;
+          // Store VCALENDAR properties in a dedicated object for easy access
+          if (Object.keys(vcalendarProps).length > 0) {
+            curr.vcalendar = vcalendarProps;
           }
 
           return curr;

--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -145,7 +145,17 @@ declare module 'node-ical' {
      */
   export type NodeIcalCallback = (error: any, data: CalendarResponse | undefined) => void;
 
-  export type CalendarResponse = Record<string, CalendarComponent>;
+  /**
+   * Response from parsing an iCalendar file.
+   * Contains calendar components indexed by UID, plus an optional vcalendar object
+   * with VCALENDAR-level properties (e.g., WR-CALNAME, WR-TIMEZONE, method, version).
+   */
+  export type CalendarResponse = {
+    /** VCALENDAR-level properties (calendar metadata) */
+    vcalendar?: VCalendar;
+    /** Calendar components (events, todos, etc.) indexed by UID */
+    [uid: string]: CalendarComponent | VCalendar | undefined;
+  };
 
   export type CalendarComponent = VTimeZone | VEvent | VCalendar;
 
@@ -267,7 +277,16 @@ declare module 'node-ical' {
   } & BaseComponent;
 
   /**
-   * Contains alls metadata of the Calendar
+   * VCALENDAR component containing calendar-level metadata.
+   * Accessible via data.vcalendar after parsing.
+   *
+   * Note: X-prefixed properties (e.g., X-WR-CALNAME) have the 'X-' prefix removed
+   * by node-ical, so X-WR-CALNAME becomes WR-CALNAME in the parsed output.
+   *
+   * @example
+   * const data = ical.parseICS(icsString);
+   * const calendarName = data.vcalendar?.['WR-CALNAME'];
+   * const timezone = data.vcalendar?.['WR-TIMEZONE'];
    */
   export type VCalendar = {
     type: 'VCALENDAR';
@@ -275,10 +294,13 @@ declare module 'node-ical' {
     version?: string;
     calscale?: 'GREGORIAN' | string;
     method?: Method;
+    /** Calendar name (X-WR-CALNAME in ICS file) */
     'WR-CALNAME'?: string;
+    /** Calendar description (X-WR-CALDESC in ICS file) */
     'WR-CALDESC'?: string;
+    /** Default timezone (X-WR-TIMEZONE in ICS file) */
     'WR-TIMEZONE'?: string;
-  } & BaseComponent;
+  };
 
   export type BaseComponent = {
     params: any[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "commonjs",
     "allowJs": true,
     "checkJs": false,
@@ -17,6 +17,7 @@
   "include": [
     "*.js",
     "*.d.ts",
-    "test/**/*.js"
+    "test/**/*.js",
+    "examples/**/*.ts"
   ]
 }


### PR DESCRIPTION
While reviewing #141, I found it was already fixed by #168. But I noticed some potential for improvements:

- Renamed `highLevel` → `vcalendarProps` for better clarity
- Added TypeScript definitions for `VCalendar`
- Added TypeScript example and README documentation

This makes the existing `data.vcalendar` feature more discoverable and type-safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added TypeScript support notes and guidance for accessing calendar metadata.

* **New Features**
  * Type definitions updated to expose calendar-level metadata (WR-CALNAME, WR-CALDESC, WR-TIMEZONE, METHOD) via a dedicated calendar metadata container for typed access.

* **Examples**
  * New TypeScript example demonstrating parsing a calendar, reading calendar metadata, and iterating events with type-safe guards.

* **Chores**
  * TypeScript build target updated to a newer ECMAScript version and examples included in build config.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->