### PR TITLE
fix: remove leading space in CLASS handler

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -1033,7 +1033,7 @@ module.exports = {
       throw new Error('duplicate DUE encountered, line=' + line);
     },
     EXDATE: exdateParameter('exdate'),
-    ' CLASS': storeParameter('class'), // Should there be a space in this property?
+    CLASS: storeParameter('class'),
     TRANSP: storeParameter('transparency'),
     GEO: geoParameter('geo'),
     'PERCENT-COMPLETE': storeParameter('completion'),


### PR DESCRIPTION
The handler ' CLASS' had a leading space since 2011, making it unreachable. CLASS still worked via the fallback handler. Fixing the typo keeps CLASS explicitly documented as a supported RFC 5545 property.

Fixes #301.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLASS property handling to ensure correct parsing and recognition of class attributes in calendar data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->