### PR TITLE
fix: remove unused params field from BEGIN handler

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -565,7 +565,7 @@ module.exports = {
     BEGIN(component, parameters, curr, stack) {
       stack.push(curr);
 
-      return {type: component, params: parameters};
+      return {type: component};
     },
     END(value, parameters, curr, stack) {
       // Original end function


### PR DESCRIPTION
Appears to have been introduced in 2011 to store BEGIN statement parameters. However, per RFC 5545, BEGIN has no parameters, so the array was always empty and unnecessary.

Fixes #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified iCalendar parser output to remove certain early-stage properties from the returned parse object. Integrations or custom code that depend on the previous output shape should be reviewed and updated for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->