### PR TITLE
fix(types): restore RFC 5545 required fields for VEvent, VTodo, VJournal

### DIFF
--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -237,6 +237,13 @@ declare module 'node-ical' {
 
   export type VEvent = CalendarComponentCommon & {
     type: 'VEVENT';
+    // RFC 5545 required fields (override optional from CalendarComponentCommon)
+    uid: string;
+    dtstamp: DateWithTimeZone;
+    start: DateWithTimeZone;
+    datetype: DateType;
+    summary: ParameterValue;
+    // VEvent-specific fields
     method?: Method;
     /** Event location – may include params (e.g., LANGUAGE, ALTREP) */
     location?: ParameterValue;
@@ -286,6 +293,10 @@ declare module 'node-ical' {
    */
   export type VTodo = CalendarComponentCommon & {
     type: 'VTODO';
+    // RFC 5545 required fields (override optional from CalendarComponentCommon)
+    uid: string;
+    dtstamp: DateWithTimeZone;
+    // VTodo-specific fields
     method?: Method;
     /** Task location – may include params (e.g., LANGUAGE, ALTREP) */
     location?: ParameterValue;
@@ -319,6 +330,10 @@ declare module 'node-ical' {
    */
   export type VJournal = CalendarComponentCommon & {
     type: 'VJOURNAL';
+    // RFC 5545 required fields (override optional from CalendarComponentCommon)
+    uid: string;
+    dtstamp: DateWithTimeZone;
+    // VJournal-specific fields
     method?: Method;
     status?: VJournalStatus;
     /**
@@ -404,9 +419,7 @@ declare module 'node-ical' {
     'WR-TIMEZONE'?: string;
   };
 
-  export type BaseComponent = {
-    params: any[];
-  };
+  export type BaseComponent = Record<string, unknown>;
 
   export type TimeZoneDef = {
     type: 'DAYLIGHT' | 'STANDARD';

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "mocha": "^11.7.5",
         "moment-timezone": "^0.6.0",
         "simple-git-hooks": "^2.13.1",
+        "typescript": "^5.9.3",
         "xo": "^1.2.3"
       },
       "engines": {
@@ -7050,7 +7051,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mocha": "^11.7.5",
     "moment-timezone": "^0.6.0",
     "simple-git-hooks": "^2.13.1",
+    "typescript": "^5.9.3",
     "xo": "^1.2.3"
   },
   "xo": {
@@ -53,7 +54,8 @@
   },
   "scripts": {
     "examples": "node examples/example-rrule-moment.js && node examples/example-rrule-luxon.js && node examples/example-rrule-dayjs.js && node examples/example-rrule-datefns.js && node examples/example-rrule-vanilla.js && node examples/example.js",
-    "test": "xo && mocha --timeout 8000",
+    "test": "npm run test:types && xo && mocha --timeout 8000",
+    "test:types": "tsc --project test/tsconfig.json",
     "lint": "xo",
     "lintfix": "xo --fix",
     "prepare": "simple-git-hooks",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node"
+  },
+  "include": ["types.test.ts", "../node-ical.d.ts"]
+}

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,207 @@
+/**
+ * TypeScript type tests to prevent regressions in type definitions.
+ * These tests verify that required fields remain required and optional fields remain optional.
+ * This file is compiled with `tsc --noEmit` but never executed.
+ */
+
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="../node-ical.d.ts" />
+
+import type * as ical from 'node-ical';
+
+// ============================================================================
+// VEvent Type Tests
+// ============================================================================
+
+// Test: VEvent required fields must be provided
+const validEvent: ical.VEvent = {
+  type: 'VEVENT',
+  uid: 'event-123',
+  dtstamp: new Date(),
+  start: new Date(),
+  datetype: 'date-time',
+  summary: 'Team Meeting',
+};
+
+// Test: VEvent required fields cannot be undefined
+const eventUid: string = validEvent.uid;
+const eventDtstamp: Date = validEvent.dtstamp;
+const eventStart: Date = validEvent.start;
+const eventDatetype: ical.DateType = validEvent.datetype;
+const eventSummary: ical.ParameterValue = validEvent.summary;
+
+// Test: VEvent optional fields can be undefined
+const eventMethod: ical.Method | undefined = validEvent.method;
+const eventLocation: ical.ParameterValue | undefined = validEvent.location;
+const eventEnd: ical.DateWithTimeZone | undefined = validEvent.end;
+const eventDescription: ical.ParameterValue | undefined = validEvent.description;
+const eventOrganizer: ical.Organizer | undefined = validEvent.organizer;
+const eventSequence: number | undefined = validEvent.sequence;
+const eventClass: ical.Class | undefined = validEvent.class;
+const eventUrl: string | undefined = validEvent.url;
+const eventCreated: ical.DateWithTimeZone | undefined = validEvent.created;
+const eventLastmodified: ical.DateWithTimeZone | undefined = validEvent.lastmodified;
+
+// Test: VEvent with all optional fields
+const fullEvent: ical.VEvent = {
+  type: 'VEVENT',
+  uid: 'event-456',
+  dtstamp: new Date(),
+  start: new Date(),
+  datetype: 'date-time',
+  summary: 'Conference',
+  method: 'PUBLISH',
+  location: 'Room 123',
+  end: new Date(),
+  description: 'Annual conference',
+  organizer: {params: {}, val: 'mailto:admin@example.com'},
+  sequence: 1,
+  class: 'PUBLIC',
+  url: 'https://example.com/event',
+  created: new Date(),
+  lastmodified: new Date(),
+  rrule: ({} as unknown) as ical.RRule,
+  status: 'CONFIRMED',
+  transparency: 'OPAQUE',
+  attendee: [],
+  categories: ['Meeting'],
+  recurrences: {},
+  alarms: [],
+};
+
+// ============================================================================
+// VTodo Type Tests
+// ============================================================================
+
+// Test: VTodo required fields must be provided
+const validTodo: ical.VTodo = {
+  type: 'VTODO',
+  uid: 'todo-123',
+  dtstamp: new Date(),
+};
+
+// Test: VTodo required fields cannot be undefined
+const todoUid: string = validTodo.uid;
+const todoDtstamp: Date = validTodo.dtstamp;
+
+// Test: VTodo optional fields can be undefined
+const todoSummary: ical.ParameterValue | undefined = validTodo.summary;
+const todoDescription: ical.ParameterValue | undefined = validTodo.description;
+const todoStart: ical.DateWithTimeZone | undefined = validTodo.start;
+const todoDue: ical.DateWithTimeZone | undefined = validTodo.due;
+const todoCompleted: ical.DateWithTimeZone | undefined = validTodo.completed;
+const todoCompletion: string | undefined = validTodo.completion;
+const todoStatus: ical.VTodoStatus | undefined = validTodo.status;
+const todoPriority: number | undefined = validTodo.priority;
+
+// Test: VTodo with all optional fields
+const fullTodo: ical.VTodo = {
+  type: 'VTODO',
+  uid: 'todo-456',
+  dtstamp: new Date(),
+  summary: 'Fix bug',
+  description: 'Fix the login issue',
+  start: new Date(),
+  due: new Date(),
+  completed: new Date(),
+  completion: '50',
+  status: 'IN-PROCESS',
+  priority: 1,
+  sequence: 0,
+  class: 'PUBLIC',
+  organizer: {params: {}, val: 'mailto:admin@example.com'},
+  categories: ['Bug'],
+  recurrences: {},
+  alarms: [],
+};
+
+// ============================================================================
+// VJournal Type Tests
+// ============================================================================
+
+// Test: VJournal required fields must be provided
+const validJournal: ical.VJournal = {
+  type: 'VJOURNAL',
+  uid: 'journal-123',
+  dtstamp: new Date(),
+};
+
+// Test: VJournal required fields cannot be undefined
+const journalUid: string = validJournal.uid;
+const journalDtstamp: Date = validJournal.dtstamp;
+
+// Test: VJournal optional fields can be undefined
+const journalSummary: ical.ParameterValue | undefined = validJournal.summary;
+const journalDescription: ical.ParameterValue | undefined = validJournal.description;
+const journalStart: ical.DateWithTimeZone | undefined = validJournal.start;
+const journalStatus: ical.VJournalStatus | undefined = validJournal.status;
+
+// Test: VJournal with all optional fields
+const fullJournal: ical.VJournal = {
+  type: 'VJOURNAL',
+  uid: 'journal-456',
+  dtstamp: new Date(),
+  summary: 'Daily log',
+  description: 'Notes from today',
+  start: new Date(),
+  status: 'FINAL',
+  sequence: 0,
+  class: 'PRIVATE',
+  organizer: {params: {}, val: 'mailto:admin@example.com'},
+  categories: ['Log'],
+  recurrences: {},
+};
+
+// ============================================================================
+// CalendarResponse Type Tests
+// ============================================================================
+
+// Test: Parsed calendar response
+const calendarData: ical.CalendarResponse = {
+  vcalendar: {
+    type: 'VCALENDAR',
+    version: '2.0',
+    prodid: '-//Test//Test//EN',
+  },
+  'event-123': validEvent,
+  'todo-123': validTodo,
+  'journal-123': validJournal,
+};
+
+// Test: Type guards work correctly
+for (const component of Object.values(calendarData)) {
+  if (component && typeof component === 'object' && 'type' in component) {
+    switch (component.type) {
+      case 'VEVENT': {
+        // Required fields must be accessible without null checks
+        const eventId: string = component.uid;
+        const eventTimestamp: Date = component.dtstamp;
+        const eventStartTime: Date = component.start;
+        break;
+      }
+
+      case 'VTODO': {
+        // Required fields must be accessible without null checks
+        const todoId: string = component.uid;
+        const todoTimestamp: Date = component.dtstamp;
+        break;
+      }
+
+      case 'VJOURNAL': {
+        // Required fields must be accessible without null checks
+        const journalId: string = component.uid;
+        const journalTimestamp: Date = component.dtstamp;
+        break;
+      }
+
+      case 'VCALENDAR':
+      case 'VTIMEZONE':
+      case 'VFREEBUSY': {
+        // These component types don't have our required field constraints
+        break;
+      }
+    }
+  }
+}
+
+// If this file compiles, all type constraints are correct.


### PR DESCRIPTION
Fixes #447 - Restores required fields that were incorrectly made optional in #443.

### Problem

When `CalendarComponentCommon` was introduced in #443 to share fields across VEVENT, VTODO, and VJOURNAL, all shared fields became optional (using `?`). This broke TypeScript compilation for users who relied on fields like `uid`, `dtstamp`, and `start` being required, causing a lot of type errors.

I’m sorry for any inconvenience.

### Solution

Override optional fields from `CalendarComponentCommon` to make RFC 5545 required fields non-optional:

**VEvent:**
- `uid` - required (RFC 5545)
- `dtstamp` - required (RFC 5545)
- `start` - required (RFC 5545 for VEVENT)
- `datetype` - required (always present with start)
- `summary` - required (practically always present)

**VTodo & VJournal:**
- `uid` - required (RFC 5545)
- `dtstamp` - required (RFC 5545)

### Note

This intentionally does **NOT** restore all previously required fields. Fields like `method`, `location`, `description`, `organizer`, `transparency`, `class`, `url`, `completion`, `created`, `lastmodified` remain optional because they are optional per RFC 5545.

### Testing

To prevent regressions like Issue #447 where fields became unintentionally optional I added TypeScript type tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stricter TypeScript typings for calendar items: required RFC‑5545 fields (e.g., uid, timestamps, start, summary) are now enforced.

* **Tests**
  * Added comprehensive type-only TypeScript tests to validate required vs optional calendar fields at compile time.

* **Chores**
  * Integrated TypeScript type checking into the test pipeline and added build scripts for time zone data updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->