### PR TITLE
refactor: update rrule-temporal and remove Google UNTIL Workaround

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -868,34 +868,6 @@ module.exports = {
                 if (timePart) {
                   rruleOnly = rruleOnly.replace(/UNTIL=\d{8}T\d{6}Z?/, `UNTIL=${datePart}`);
                 }
-              } else if (!timePart) {
-                // DATE-TIME DTSTART but UNTIL has no time part (Google Calendar bug)
-                // Interpret UNTIL as end-of-day (23:59:59) in the event's timezone, then convert to UTC
-                let converted = false;
-                if (curr.start.tz) {
-                  try {
-                    const tzInfo = tzUtil.resolveTZID(curr.start.tz);
-                    const untilLocal = datePart + 'T235959'; // End of day in local timezone
-
-                    let untilDateObject;
-                    if (tzInfo.iana && tzUtil.isValidIana(tzInfo.iana)) {
-                      untilDateObject = tzUtil.parseDateTimeInZone(untilLocal, tzInfo.iana);
-                    } else if (Number.isFinite(tzInfo.offsetMinutes) && typeof tzInfo.offset === 'string' && tzInfo.offset) {
-                      untilDateObject = tzUtil.parseWithOffset(untilLocal, tzInfo.offset);
-                    }
-
-                    if (untilDateObject) {
-                      const untilUtc = untilDateObject.toISOString().replaceAll(/[-:]/g, '').replace(/\.\d{3}/, '');
-                      rruleOnly = rruleOnly.replace(/UNTIL=(\d{8})(?!T)/, `UNTIL=${untilUtc}`);
-                      converted = true;
-                    }
-                  } catch {/* Fall through to UTC fallback */}
-                }
-
-                if (!converted) {
-                  // No timezone info available - assume UNTIL date means end-of-day UTC
-                  rruleOnly = rruleOnly.replace(/UNTIL=(\d{8})(?!T)/, 'UNTIL=$1T235959Z');
-                }
               } else if (timePart && !zSuffix) {
                 // DATE-TIME without Z: convert to UTC if we have a timezone, otherwise just append Z
                 let converted = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "rrule-temporal": "^1.4.5"
+        "rrule-temporal": "^1.4.6"
       },
       "devDependencies": {
         "date-fns": "^4.1.0",
@@ -6079,9 +6079,9 @@
       "license": "MIT"
     },
     "node_modules/rrule-temporal": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.4.5.tgz",
-      "integrity": "sha512-g0qDEx7Wk1eaOKyZvBSTAz/DAfPnS+7GZT3vRShue6zIGCjkHWJs6evnGb7Nx2SVGKxOyMDUtKBBI53HMaFDKQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.4.6.tgz",
+      "integrity": "sha512-eRruK01K8uu0VWgn+lvKYXGZCER7eI2EaoAhsh5wwHaYMc4jPJ1cvY+bD0hBbYwCucggMpjtuwH2RpEH9oLfWg==",
       "license": "MIT",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "rrule-temporal": "^1.4.5"
+    "rrule-temporal": "^1.4.6"
   },
   "overrides": {
     "@js-temporal/polyfill": "npm:temporal-polyfill@^0.3.0"

--- a/test/google-calendar-until-bug.test.js
+++ b/test/google-calendar-until-bug.test.js
@@ -5,6 +5,16 @@ const assert = require('node:assert/strict');
 const {describe, it} = require('mocha');
 const ical = require('../node-ical.js');
 
+/**
+ * Regression tests for Google Calendar's UNTIL format bug (#435, rrule-temporal#104).
+ *
+ * Google Calendar sometimes produces RRULE with DATE-only UNTIL when DTSTART is DATE-TIME:
+ *   DTSTART;TZID=Europe/Oslo:20211216T180000
+ *   RRULE:FREQ=WEEKLY;UNTIL=20211216  ← Missing time component
+ *
+ * Since rrule-temporal 1.4.6, this normalization is handled upstream by the library.
+ * These tests verify that the library correctly interprets UNTIL in the event's timezone.
+ */
 describe('Google Calendar UNTIL format bug (regression test for #435 and rrule-temporal #104)', function () {
   it('should parse DATE-TIME event with TZID when UNTIL has no time component', function () {
     // Google Calendar sometimes produces RRULE with UNTIL that has no time part


### PR DESCRIPTION
This PR updates the functional RRULE processing to `rrule-temporal@1.4.6` and removes the previously local workaround for Google Calendar's DATE-only `UNTIL` with DATE-TIME `DTSTART`.

## Changes
- Dependency update to `rrule-temporal@1.4.6`
- Removes the local "Google UNTIL workaround" in `ical.js`
- Adds test documentation in `test/google-calendar-until-bug.test.js` clarifying that responsibility now lies with `rrule-temporal`

## Workaround History
- The removed workaround was only recently added: 1155e5a9f3fba7ed996376353b0c741630bc0992
  - Commit: `fix: handle Google Calendar UNTIL without time respecting event timezone (#436)`
- This PR removes the workaround again, as the fix is now handled upstream in `rrule-temporal@1.4.6`

## Benefits
- **Less special-case logic in parser:** 28 lines of workaround code eliminated
- **Clearer responsibilities:** UNTIL normalization belongs with the library that actually interprets RRULE
- **Reduced maintenance burden:** less corner-case code to maintain in `node-ical`
- **Better traceability:** test file explicitly documents the Google case and expected interpretation

## Risk / Impact
- Functional change intentionally depends on `rrule-temporal@1.4.6`
- No API breaking change in `node-ical`; behavior remains protected by regression tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of recurring event end dates with UNTIL values.

* **Chores**
  * Updated rrule-temporal dependency to v1.4.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->