### PR TITLE
fix: preserve timezone metadata on expanded event instances

### DIFF
--- a/node-ical.d.ts
+++ b/node-ical.d.ts
@@ -125,9 +125,9 @@ declare module 'node-ical' {
    */
   export type EventInstance = {
     /** Start date/time of this instance */
-    start: Date;
+    start: DateWithTimeZone;
     /** End date/time of this instance */
-    end: Date;
+    end: DateWithTimeZone;
     /** Event summary/title - copied from event, may include params */
     summary: ParameterValue;
     /** Whether this is a full-day event (date-only, no time component) */


### PR DESCRIPTION
EventInstance.start and .end now use DateWithTimeZone type and preserve .tz and .dateOnly metadata from the original event.

- Add copyDateMeta() helper to copy timezone metadata between dates
- Update TypeScript types: EventInstance dates now DateWithTimeZone
- Apply metadata preservation in processRecurringInstance and processNonRecurringEvent
- Add tests for timezone and dateOnly metadata preservation

Fixes #455.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Event instances now preserve timezone information and full-day (date-only) flags for both recurring and non-recurring events, ensuring consistent displayed times across occurrences.
* **Tests**
  * Added tests validating timezone and date-only metadata are retained for all expanded recurring instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->