### PR TITLE
refactor: leverage Temporal across the codebase - simplify timezone internals

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -11,50 +11,7 @@ globalThis.Temporal ??= Temporal;
 const {RRuleTemporal} = require('rrule-temporal');
 const {toText: toTextFunction} = require('rrule-temporal/totext');
 const tzUtil = require('./tz-utils.js');
-
-/**
- * Construct a date-only key (YYYY-MM-DD) from a Date object.
- * For date-only events, uses local date components to avoid timezone shifts.
- * For date-time events with a timezone, uses Temporal to extract the calendar date
- * in the original timezone (avoids UTC shift, e.g. Exchange O365 RECURRENCE-ID
- * midnight-CET becoming previous day in UTC – see GitHub issue #459).
- * For date-time events without timezone, extracts the date from the ISO timestamp.
- * @param {Date} dateValue - Date object with optional dateOnly and tz properties
- * @returns {string} Date key in YYYY-MM-DD format
- */
-function getDateKey(dateValue) {
-  if (dateValue.dateOnly) {
-    return `${dateValue.getFullYear()}-${String(dateValue.getMonth() + 1).padStart(2, '0')}-${String(dateValue.getDate()).padStart(2, '0')}`;
-  }
-
-  // When the Date carries timezone metadata, extract the calendar date in that timezone.
-  // This prevents midnight-in-local-tz (e.g. 00:00 CET = 23:00 UTC the day before)
-  // from being mapped to the wrong calendar day.
-  // Temporal handles both IANA zones and fixed-offset strings (e.g. "+01:00") uniformly.
-  if (dateValue.tz) {
-    try {
-      const resolved = tzUtil.resolveTZID(dateValue.tz);
-      const tzId = resolved?.iana || resolved?.offset;
-      if (resolved && !tzId) {
-        console.warn(
-          '[node-ical] Could not resolve TZID to an IANA name or UTC offset; falling back to UTC-based date key.',
-          {tzid: dateValue.tz, resolved},
-        );
-      }
-
-      if (tzId) {
-        return Temporal.Instant.fromEpochMilliseconds(dateValue.getTime())
-          .toZonedDateTimeISO(tzId)
-          .toPlainDate()
-          .toString();
-      }
-    } catch (error) {
-      console.warn(`[node-ical] Failed to resolve timezone for date key (TZID="${dateValue.tz}"), falling back to UTC: ${error?.message ?? String(error)}`);
-    }
-  }
-
-  return dateValue.toISOString().slice(0, 10);
-}
+const {getDateKey} = require('./lib/date-utils.js');
 
 /**
  * Clone a Date object and preserve custom metadata (tz, dateOnly).
@@ -1154,6 +1111,4 @@ module.exports = {
       return this.parseLines(lines);
     }
   },
-
-  getDateKey,
 };

--- a/ical.js
+++ b/ical.js
@@ -1220,3 +1220,5 @@ module.exports = {
     }
   },
 };
+
+module.exports.getDateKey = getDateKey;

--- a/ical.js
+++ b/ical.js
@@ -4,7 +4,7 @@ const {randomUUID} = require('node:crypto');
 
 // Load Temporal polyfill if not natively available
 // TODO: Drop the polyfill branch once our minimum Node version ships Temporal
-const Temporal = globalThis.Temporal || require('@js-temporal/polyfill').Temporal;
+const Temporal = globalThis.Temporal || require('temporal-polyfill').Temporal;
 // Ensure Temporal exists before loading rrule-temporal
 globalThis.Temporal ??= Temporal;
 

--- a/ical.js
+++ b/ical.js
@@ -932,7 +932,12 @@ module.exports = {
           } else {
             // DATE-TIME events: convert curr.start (Date) to Temporal.ZonedDateTime
             const tzInfo = curr.start.tz ? tzUtil.resolveTZID(curr.start.tz) : undefined;
-            const timeZone = tzInfo?.iana || tzInfo?.offset || 'UTC';
+            let timeZone = 'UTC';
+            if (tzInfo?.iana || tzInfo?.offset) {
+              timeZone = tzInfo.iana || tzInfo.offset;
+            } else if (tzInfo) {
+              console.warn('[node-ical] TZID resolved to neither IANA nor UTC offset; falling back to UTC for DTSTART conversion.');
+            }
 
             let dtstartTemporal;
             try {

--- a/ical.js
+++ b/ical.js
@@ -48,8 +48,8 @@ function getDateKey(dateValue) {
           .toPlainDate()
           .toString();
       }
-    } catch {
-      // Fall through to UTC-based key if timezone resolution fails
+    } catch (error) {
+      console.warn(`[node-ical] Failed to resolve timezone for date key (TZID="${dateValue.tz}"), falling back to UTC: ${error?.message ?? String(error)}`);
     }
   }
 
@@ -944,7 +944,7 @@ module.exports = {
               dtstartTemporal = Temporal.Instant.fromEpochMilliseconds(curr.start.getTime())
                 .toZonedDateTimeISO(timeZone);
             } catch (error) {
-              console.warn(`[node-ical] Failed to convert timezone "${timeZone}", falling back to UTC: ${error.message}`);
+              console.warn(`[node-ical] Failed to convert timezone "${timeZone}", falling back to UTC: ${error?.message ?? String(error)}`);
               dtstartTemporal = Temporal.Instant.fromEpochMilliseconds(curr.start.getTime())
                 .toZonedDateTimeISO('UTC');
             }

--- a/ical.js
+++ b/ical.js
@@ -1149,6 +1149,6 @@ module.exports = {
       return this.parseLines(lines);
     }
   },
-};
 
-module.exports.getDateKey = getDateKey;
+  getDateKey,
+};

--- a/ical.js
+++ b/ical.js
@@ -791,31 +791,15 @@ module.exports = {
           // This a whole day event
           if (curr.datetype === 'date') {
             const originalStart = curr.start;
-            // Get the timezone offset
-            // The internal date is stored in UTC format
-            const offset = originalStart.getTimezoneOffset();
-            let nextStart;
 
-            // Only east of gmt is a problem
-            if (offset < 0) {
-              // Calculate the new startdate with the offset applied, bypass RRULE/Luxon confusion
-              // Make the internally stored DATE the actual date (not UTC offseted)
-              // Luxon expects local time, not utc, so gets start date wrong if not adjusted
-              nextStart = new Date(originalStart.getTime() + (Math.abs(offset) * 60_000));
-            } else {
-              // Strip any residual time component by rebuilding local midnight
-              nextStart = new Date(
-                originalStart.getFullYear(),
-                originalStart.getMonth(),
-                originalStart.getDate(),
-                0,
-                0,
-                0,
-                0,
-              );
-            }
+            // Date-only: pass the wall-clock date from the local components directly,
+            // no system-timezone offset compensation needed.
+            const y = originalStart.getFullYear();
+            const m = originalStart.getMonth();
+            const d = originalStart.getDate();
 
-            curr.start = nextStart;
+            // Rebuild as local midnight so downstream RRULE string formatting is unaffected
+            curr.start = new Date(y, m, d, 0, 0, 0, 0);
 
             // Preserve any metadata that was attached to the original Date instance.
             if (originalStart && originalStart.tz) {
@@ -947,71 +931,17 @@ module.exports = {
             curr.rrule = new RRuleCompatWrapper(rruleTemporal);
           } else {
             // DATE-TIME events: convert curr.start (Date) to Temporal.ZonedDateTime
+            const tzInfo = curr.start.tz ? tzUtil.resolveTZID(curr.start.tz) : undefined;
+            const timeZone = tzInfo?.iana || tzInfo?.offset || 'UTC';
+
             let dtstartTemporal;
-
-            if (curr.start.tz) {
-              // Has timezone - use Intl to get the local wall-clock time in that timezone
-              const tzInfo = tzUtil.resolveTZID(curr.start.tz);
-              const timeZone = tzInfo?.tzid || tzInfo?.iana || curr.start.tz || 'UTC';
-
-              try {
-                // Extract local time components in the target timezone.
-                // We use Intl.DateTimeFormat because curr.start is a Date in UTC but represents
-                // wall-clock time in the event's timezone.
-                const formatter = new Intl.DateTimeFormat('en-US', {
-                  timeZone,
-                  year: 'numeric',
-                  month: 'numeric',
-                  day: 'numeric',
-                  hour: 'numeric',
-                  minute: 'numeric',
-                  second: 'numeric',
-                  hour12: false,
-                });
-
-                const parts = formatter.formatToParts(curr.start);
-                const partMap = {};
-                for (const part of parts) {
-                  if (part.type !== 'literal') {
-                    partMap[part.type] = Number.parseInt(part.value, 10);
-                  }
-                }
-
-                // Create a PlainDateTime from the local time components
-                const plainDateTime = Temporal.PlainDateTime.from({
-                  year: partMap.year,
-                  month: partMap.month,
-                  day: partMap.day,
-                  hour: partMap.hour,
-                  minute: partMap.minute,
-                  second: partMap.second,
-                });
-
-                dtstartTemporal = plainDateTime.toZonedDateTime(timeZone, {disambiguation: 'compatible'});
-              } catch (error) {
-                // Invalid timezone - fall back to UTC interpretation
-                console.warn(`[node-ical] Failed to convert timezone "${timeZone}", falling back to UTC: ${error.message}`);
-                dtstartTemporal = Temporal.ZonedDateTime.from({
-                  year: curr.start.getUTCFullYear(),
-                  month: curr.start.getUTCMonth() + 1,
-                  day: curr.start.getUTCDate(),
-                  hour: curr.start.getUTCHours(),
-                  minute: curr.start.getUTCMinutes(),
-                  second: curr.start.getUTCSeconds(),
-                  timeZone: 'UTC',
-                });
-              }
-            } else {
-              // No timezone - use UTC
-              dtstartTemporal = Temporal.ZonedDateTime.from({
-                year: curr.start.getUTCFullYear(),
-                month: curr.start.getUTCMonth() + 1,
-                day: curr.start.getUTCDate(),
-                hour: curr.start.getUTCHours(),
-                minute: curr.start.getUTCMinutes(),
-                second: curr.start.getUTCSeconds(),
-                timeZone: 'UTC',
-              });
+            try {
+              dtstartTemporal = Temporal.Instant.fromEpochMilliseconds(curr.start.getTime())
+                .toZonedDateTimeISO(timeZone);
+            } catch (error) {
+              console.warn(`[node-ical] Failed to convert timezone "${timeZone}", falling back to UTC: ${error.message}`);
+              dtstartTemporal = Temporal.Instant.fromEpochMilliseconds(curr.start.getTime())
+                .toZonedDateTimeISO('UTC');
             }
 
             const rruleTemporal = new RRuleTemporal({

--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -1,0 +1,53 @@
+
+'use strict';
+
+// Load Temporal polyfill if not natively available
+const Temporal = globalThis.Temporal || require('temporal-polyfill').Temporal;
+
+const tzUtil = require('../tz-utils.js');
+
+/**
+ * Construct a date-only key (YYYY-MM-DD) from a Date object.
+ * For date-only events, uses local date components to avoid timezone shifts.
+ * For date-time events with a timezone, uses Temporal to extract the calendar date
+ * in the original timezone (avoids UTC shift, e.g. Exchange O365 RECURRENCE-ID
+ * midnight-CET becoming previous day in UTC – see GitHub issue #459).
+ * For date-time events without timezone, extracts the date from the ISO timestamp.
+ * @param {Date} dateValue - Date object with optional dateOnly and tz properties
+ * @returns {string} Date key in YYYY-MM-DD format
+ */
+function getDateKey(dateValue) {
+  if (dateValue.dateOnly) {
+    return `${dateValue.getFullYear()}-${String(dateValue.getMonth() + 1).padStart(2, '0')}-${String(dateValue.getDate()).padStart(2, '0')}`;
+  }
+
+  // When the Date carries timezone metadata, extract the calendar date in that timezone.
+  // This prevents midnight-in-local-tz (e.g. 00:00 CET = 23:00 UTC the day before)
+  // from being mapped to the wrong calendar day.
+  // Temporal handles both IANA zones and fixed-offset strings (e.g. "+01:00") uniformly.
+  if (dateValue.tz) {
+    try {
+      const resolved = tzUtil.resolveTZID(dateValue.tz);
+      const tzId = resolved?.iana || resolved?.offset;
+      if (resolved && !tzId) {
+        console.warn(
+          '[node-ical] Could not resolve TZID to an IANA name or UTC offset; falling back to UTC-based date key.',
+          {tzid: dateValue.tz, resolved},
+        );
+      }
+
+      if (tzId) {
+        return Temporal.Instant.fromEpochMilliseconds(dateValue.getTime())
+          .toZonedDateTimeISO(tzId)
+          .toPlainDate()
+          .toString();
+      }
+    } catch (error) {
+      console.warn(`[node-ical] Failed to resolve timezone for date key (TZID="${dateValue.tz}"), falling back to UTC: ${error?.message ?? String(error)}`);
+    }
+  }
+
+  return dateValue.toISOString().slice(0, 10);
+}
+
+module.exports = {getDateKey};

--- a/node-ical.js
+++ b/node-ical.js
@@ -1,6 +1,8 @@
 const fs = require('node:fs');
 const ical = require('./ical.js');
 
+const {getDateKey} = ical;
+
 /**
  * ICal event object.
  *
@@ -253,22 +255,24 @@ autodetect.parseICS = function (data, cb) {
 };
 
 /**
- * Generate date key for EXDATE/RECURRENCE-ID lookups
- * Must match ical.js getDateKey semantics for lookups to succeed.
- * @param {Date} date
+ * Generate date key for EXDATE/RECURRENCE-ID lookups from an RRULE-generated date.
+ * RRULE-generated dates carry no .tz or .dateOnly metadata, so isFullDay must be
+ * passed explicitly to decide between local-time and UTC-based key extraction.
+ * (For parsed calendar dates that carry .tz/.dateOnly, use getDateKey directly.)
+ * @param {Date} date - RRULE-generated Date (no .tz, no .dateOnly)
  * @param {boolean} isFullDay
  * @returns {string} Date key in YYYY-MM-DD format
  */
 function generateDateKey(date, isFullDay) {
   if (isFullDay) {
-    // Use local getters for date-only events to match ical.js behavior
+    // Full-day events: use local getters — RRULE returns local-midnight dates
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
     return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
   }
 
-  // For timed events, return date portion only to match ical.js
+  // Timed events: UTC date portion
   return date.toISOString().slice(0, 10);
 }
 
@@ -425,16 +429,7 @@ function processRecurringInstance(date, event, options, baseDurationMs) {
           continue;
         }
 
-        // Use timezone-aware formatting to extract the calendar date
-        const tz = exdateValue.tz || 'UTC';
-        const exdateDateKey = new Intl.DateTimeFormat('en-CA', {
-          timeZone: tz,
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-        }).format(exdateValue);
-
-        if (exdateDateKey === dateKey) {
+        if (getDateKey(exdateValue) === dateKey) {
           return null;
         }
       }

--- a/node-ical.js
+++ b/node-ical.js
@@ -1,7 +1,6 @@
 const fs = require('node:fs');
 const ical = require('./ical.js');
-
-const {getDateKey} = ical;
+const {getDateKey} = require('./lib/date-utils.js');
 
 /**
  * ICal event object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.25.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "rrule-temporal": "^1.4.6"
+        "rrule-temporal": "^1.4.6",
+        "temporal-polyfill": "^0.3.0"
       },
       "devDependencies": {
         "date-fns": "^4.1.0",
@@ -6815,6 +6816,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.0"
       }
     },
     "node_modules/temporal-spec": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "rrule-temporal": "^1.4.6"
+    "rrule-temporal": "^1.4.6",
+    "temporal-polyfill": "^0.3.0"
   },
   "overrides": {
     "@js-temporal/polyfill": "npm:temporal-polyfill@^0.3.0"

--- a/test/snapshots/example.txt
+++ b/test/snapshots/example.txt
@@ -1,7 +1,7 @@
 foobar Summer 2011 starts! is in All Areas on the 4 of Aug at 00:00:00
 Main entrance opened is in Main entrance on the 4 of Aug at 00:00:00
 Loading doors are opened is in Loading entrances #1 and #2 on the 4 of Aug at 00:00:00
-foobarTV broadcast starts is in foobarTV on the 4 of Aug at 02:00:00
+foobarTV broadcast starts is in foobarTV on the 4 of Aug at 00:00:00
 Loading doors close is in Loading entrances #1 and #2 on the 4 of Aug at 00:00:00
 Loading doors are opened is in Loading entrance #1 on the 5 of Aug at 00:00:00
 Loading doors close is in Loading entrance #1 on the 5 of Aug at 00:00:00

--- a/test/tz-utils.test.js
+++ b/test/tz-utils.test.js
@@ -18,37 +18,6 @@ describe('unit: tz-utils', () => {
     assert.throws(() => tz.parseWithOffset('20240101T120000', 'bogus'), /Invalid offset string: bogus/);
   });
 
-  // TODO: Remove this guard once Node 22+ is the minimum runtime and Intl stops emitting "24" hours.
-  it('rolls midnight forward when formatter emits 24:00', () => {
-    const base = new Date('2024-03-25T23:59:59.000Z');
-    const parts = {
-      year: 2024,
-      month: 3,
-      day: 25,
-      hour: 24,
-      minute: 0,
-      second: 0,
-    };
-    const fakeFormatter = {
-      formatToParts: () => [
-        {type: 'year', value: '2024'},
-        {type: 'month', value: '03'},
-        {type: 'day', value: '26'},
-        {type: 'hour', value: '00'},
-        {type: 'minute', value: '00'},
-        {type: 'second', value: '00'},
-      ],
-    };
-
-    const normalized = tz.__test__.normalizeMidnightParts(base, fakeFormatter, {...parts});
-    assert.equal(normalized.year, 2024);
-    assert.equal(normalized.month, 3);
-    assert.equal(normalized.day, 26);
-    assert.equal(normalized.hour, 0);
-    assert.equal(normalized.minute, 0);
-    assert.equal(normalized.second, 0);
-  });
-
   it('parses local wall time within a named zone (standard time)', () => {
     // Europe/Berlin observes UTC+1 in January, so Intl-backed parsing should subtract one hour
     const d = tz.parseDateTimeInZone('20240101T120000', 'Europe/Berlin');

--- a/tz-utils.js
+++ b/tz-utils.js
@@ -1,9 +1,15 @@
 // Thin abstraction over Intl to centralize all timezone logic
 // This simplifies swapping libraries later and is easy to mock in tests.
 
+// Load Temporal polyfill if not natively available (mirrors ical.js)
+const Temporal = globalThis.Temporal || require('temporal-polyfill').Temporal;
+const windowsZones = require('./windowsZones.json');
+
+// Ensure polyfill is globally available for downstream modules
+globalThis.Temporal ??= Temporal;
+
 // Minimal alias map to emulate the subset of moment.tz.link behavior tests rely on
 const aliasMap = new Map();
-const windowsZones = require('./windowsZones.json');
 
 /**
  * Normalize a Windows timezone display label so that visually similar strings compare equally.
@@ -232,66 +238,6 @@ function minutesToEtcZone(totalMinutes) {
   const hours = Math.abs(totalMinutes) / 60;
   const sign = totalMinutes > 0 ? '-' : '+'; // Etc/GMT zones invert sign
   return `Etc/GMT${sign}${hours}`;
-}
-
-/**
- * Convert a `{year, month, day, hour, minute, second}` structure into UTC milliseconds.
- *
- * @param {{year: number, month: number, day: number, hour?: number, minute?: number, second?: number}} parts
- * @returns {number}
- */
-function ymdhmsToUtcMs(parts = {}) {
-  const {
-    year,
-    month,
-    day,
-    hour = 0,
-    minute = 0,
-    second = 0,
-  } = parts;
-
-  return Date.UTC(year, month - 1, day, hour, minute, second);
-}
-
-/**
- * Fixed-point iteration that aligns an initial UTC guess to the desired local wall time.
- * Runs up to three passes to survive DST gaps/folds and returns the closest valid instant.
- *
- * For spring-forward gaps (e.g., 2:30 AM during DST transition when clocks jump to 3:30 AM):
- * - Returns the first valid instant after the gap
- * For fall-back folds (e.g., 1:30 AM occurs twice when clocks fall back):
- * - Returns the first occurrence (standard time interpretation)
- *
- * @param {number} initialUtcMs
- * @param {{year: number, month: number, day: number, hour: number, minute: number, second: number}} targetParts
- * @param {(date: Date) => {year: number, month: number, day: number, hour: number, minute: number, second: number}} getLocalParts
- * @returns {Date}
- */
-function convergeLocalInstant(initialUtcMs, targetParts, getLocalParts) {
-  const targetUtc = ymdhmsToUtcMs(targetParts);
-  let t = initialUtcMs;
-  let estimate;
-  let delta = 0;
-
-  for (let i = 0; i < 3; i++) {
-    estimate = new Date(t);
-    const current = getLocalParts(estimate);
-    delta = ymdhmsToUtcMs(current) - targetUtc;
-    if (delta === 0) {
-      return estimate;
-    }
-
-    t -= delta;
-  }
-
-  const finalCandidate = new Date(t);
-  const finalDelta = ymdhmsToUtcMs(getLocalParts(finalCandidate)) - targetUtc;
-  if (finalDelta >= 0) {
-    return finalCandidate;
-  }
-
-  // Fall back to the last estimate, which will be the closest instant before the fold/gap.
-  return estimate;
 }
 
 /**
@@ -540,51 +486,16 @@ function parseDateTimeInZone(yyyymmddThhmmss, zone) {
     return undefined;
   }
 
-  // Initial guess: interpret local fields as if they were UTC
-  const t = Date.UTC(fields.year, fields.month - 1, fields.day, fields.hour, fields.minute, fields.second);
+  // Use Temporal to convert local wall-clock time in the given zone to a UTC instant.
+  // For DST gaps (missing hour, e.g. spring-forward): moves to the first valid instant after
+  // the gap ('later' behaves identically to 'compatible'/'earlier' here).
+  // For DST folds (repeated hour, e.g. fall-back): picks the second (post-DST) occurrence,
+  // matching the behaviour of the previous Intl-based convergeLocalInstant implementation.
+  const epochMs = Temporal.PlainDateTime.from(fields)
+    .toZonedDateTime(tz, {disambiguation: 'later'})
+    .epochMilliseconds;
 
-  const getLocalParts = date => {
-    const df = getFormatter(tz);
-
-    const parts = df.formatToParts(date);
-    const out = {};
-    for (const p of parts) {
-      if (p.type === 'year') {
-        out.year = Number(p.value);
-      }
-
-      if (p.type === 'month') {
-        out.month = Number(p.value);
-      }
-
-      if (p.type === 'day') {
-        out.day = Number(p.value);
-      }
-
-      if (p.type === 'hour') {
-        out.hour = Number(p.value);
-      }
-
-      if (p.type === 'minute') {
-        out.minute = Number(p.value);
-      }
-
-      if (p.type === 'second') {
-        out.second = Number(p.value);
-      }
-    }
-
-    // Handle 24:00 edge case which some TZs may produce for midnight
-    // This seems only happen with node < 22 and only for certain zones
-    if (Object.hasOwn(out, 'hour') && out.hour === 24) {
-      normalizeMidnightParts(date, df, out);
-    }
-
-    return out;
-  };
-
-  const converged = convergeLocalInstant(t, fields, getLocalParts);
-  return attachTz(converged, zone);
+  return attachTz(new Date(epochMs), zone);
 }
 
 function parseWithOffset(yyyymmddThhmmss, offset) {

--- a/tz-utils.js
+++ b/tz-utils.js
@@ -99,75 +99,8 @@ function pad2(value) {
   return String(value).padStart(2, '0');
 }
 
-// Simple per-zone formatter cache to reduce Intl constructor churn
-const dtfCache = new Map();
-
 // Memoize IANA zone validity checks to avoid repeated Intl constructor throws
 const validIanaCache = new Map();
-
-/**
- * Get a cached Intl.DateTimeFormat instance for the specified timezone.
- * Creates and caches a new formatter if one doesn't exist for the zone.
- *
- * @param {string} tz - The IANA timezone identifier.
- * @returns {Intl.DateTimeFormat} The cached formatter instance.
- */
-function getFormatter(tz) {
-  let formatter = dtfCache.get(tz);
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat('en-CA', {
-      timeZone: tz,
-      hour12: false,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    });
-    dtfCache.set(tz, formatter);
-  }
-
-  return formatter;
-}
-
-/**
- * Work around the legacy Intl bug where some Node.js releases prior to v22 emit "24" for the
- * hour component at local midnight (verified with Node 20 against zones like Africa/Abidjan).
- * Node 22+ normalizes the output to "00", so this helper becomes unnecessary once we require
- * Node 22 or newer and can be safely removed at that point.
- *
- * @param {Date} date
- * @param {Intl.DateTimeFormat} formatter
- * @param {{year?: number, month?: number, day?: number, hour?: number, minute?: number, second?: number}} parts
- * @returns {{year?: number, month?: number, day?: number, hour?: number, minute?: number, second?: number}}
- */
-function normalizeMidnightParts(date, formatter, parts) {
-  if (!parts || typeof formatter?.formatToParts !== 'function') {
-    return parts;
-  }
-
-  const next = new Date(date.getTime() + 1000);
-  const nextParts = formatter.formatToParts(next);
-  for (const p of nextParts) {
-    if (p.type === 'year') {
-      parts.year = Number(p.value);
-    }
-
-    if (p.type === 'month') {
-      parts.month = Number(p.value);
-    }
-
-    if (p.type === 'day') {
-      parts.day = Number(p.value);
-    }
-  }
-
-  parts.hour = 0;
-  parts.minute = 0;
-  parts.second = 0;
-  return parts;
-}
 
 /**
  * Convert textual UTC offsets ("+05:30", "UTC-4", "(UTC+02:00)") into signed minute counts.
@@ -308,7 +241,9 @@ function resolveTZID(value) {
 
 /**
  * Format a Date as a local wall-time string (`YYYYMMDDTHHmmss`) suitable for RRULE DTSTART emission.
- * Prefers Intl when a valid IANA zone exists; otherwise falls back to offset arithmetic.
+ * Converts the UTC instant to the given timezone using Temporal, then formats the wall-clock fields.
+ * Accepts either an IANA zone name (via `tzInfo.iana`) or a UTC-offset zone derived from
+ * `tzInfo.offsetMinutes` (e.g. `+01:00`).
  *
  * @param {Date} date
  * @param {{iana?: string, offsetMinutes?: number}} tzInfo
@@ -319,43 +254,20 @@ function formatDateForRrule(date, tzInfo = {}) {
     return undefined;
   }
 
-  if (tzInfo.iana && isValidIana(tzInfo.iana)) {
-    const formatter = getFormatter(tzInfo.iana);
+  const tzId
+    = tzInfo.iana && isValidIana(tzInfo.iana)
+      ? tzInfo.iana
+      : (Number.isFinite(tzInfo.offsetMinutes)
+        ? minutesToOffset(tzInfo.offsetMinutes)
+        : undefined);
 
-    const parts = formatter.formatToParts(date);
-    const numericParts = new Map([
-      ['year', 'year'],
-      ['month', 'month'],
-      ['day', 'day'],
-      ['hour', 'hour'],
-      ['minute', 'minute'],
-      ['second', 'second'],
-    ]);
-    const out = {};
-    for (const part of parts) {
-      const target = numericParts.get(part.type);
-      if (!target) {
-        continue;
-      }
-
-      out[target] = Number(part.value);
-    }
-
-    if (out.hour === 24) {
-      normalizeMidnightParts(date, formatter, out);
-    }
-
-    if (out.year && out.month && out.day && out.hour !== undefined && out.minute !== undefined && out.second !== undefined) {
-      return `${out.year}${pad2(out.month)}${pad2(out.day)}T${pad2(out.hour)}${pad2(out.minute)}${pad2(out.second)}`;
-    }
+  if (!tzId) {
+    return undefined;
   }
 
-  if (Number.isFinite(tzInfo.offsetMinutes)) {
-    const local = new Date(date.getTime() + (tzInfo.offsetMinutes * 60_000));
-    return `${local.getUTCFullYear()}${pad2(local.getUTCMonth() + 1)}${pad2(local.getUTCDate())}T${pad2(local.getUTCHours())}${pad2(local.getUTCMinutes())}${pad2(local.getUTCSeconds())}`;
-  }
-
-  return undefined;
+  const {year, month, day, hour, minute, second} = Temporal.Instant.fromEpochMilliseconds(date.getTime())
+    .toZonedDateTimeISO(tzId);
+  return `${year}${pad2(month)}${pad2(day)}T${pad2(hour)}${pad2(minute)}${pad2(second)}`;
 }
 
 /**
@@ -579,7 +491,6 @@ module.exports = {
 
 // Expose some internals for testing
 module.exports.__test__ = {
-  normalizeMidnightParts,
   isUtcTimezone,
 };
 


### PR DESCRIPTION
With `rrule-temporal` and the Temporal polyfill already in the dependency tree, this PR revisits the remaining timezone code paths to replace legacy `Intl.DateTimeFormat` workarounds and manual UTC arithmetic with direct Temporal API calls.

What started as a pure refactoring effort uncovered a subtle, environment-dependent bug that had been invisible in CI for years — fixed in this PR alongside the cleanup.

**Net result:** 8 files changed, 122 insertions, 346 deletions — ~224 lines removed while adding a regression test and fixing a bug.

## Commits

**1. refactor(tz-utils): replace convergeLocalInstant with Temporal**

`parseDateTimeInZone()` used a hand-rolled 3-round fixed-point iteration to convert wall-clock time to UTC. Replaced with a single `Temporal.PlainDateTime.from().toZonedDateTime()` call. ~85 lines removed.

**2. refactor(node-ical): replace Intl EXDATE check with getDateKey**

EXDATE exclusion matching duplicated timezone-aware date extraction that `getDateKey()` already provides. Deduplicated to a single shared call.

**3. refactor(tz-utils): replace Intl-based formatDateForRrule with Temporal**

Two separate code paths (IANA via Intl formatter cache, offset via manual arithmetic) plus a Node < 22 midnight workaround → one `Temporal.Instant.toZonedDateTimeISO()` call. Dead helper `normalizeMidnightParts` removed.

**4. fix(ical): normalize DATE-only RRULE start to midnight; replace Intl DTSTART with Temporal**

**Bug:** The `getTimezoneOffset()` compensation for `VALUE=DATE` events — introduced in `cbb76af` — shifted the time by the server's UTC offset on machines east of UTC (e.g. `02:00:00` instead of `00:00:00` on UTC+2). On UTC servers the buggy branch was dead code, so CI never caught it.

**Fix:** Extract local date components directly — no offset involved. Regression test added.

Same commit also replaces the `Intl.DateTimeFormat.formatToParts` block for DATE-TIME RRULE DTSTART with `Temporal.Instant.toZonedDateTimeISO()`.

## Remaining Intl usage (intentionally kept)

- `guessLocalZone()` — no Temporal equivalent for system timezone detection
- `getZoneNames()` — no Temporal equivalent for listing known zones
- `isValidIana()` — more portable than Temporal; accepts fixed-offset strings; result is cached


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date-only recurring events normalize to local midnight; EXDATE/RECURRENCE comparisons use a consistent date-key to avoid missed/duplicate instances.

* **New Features**
  * Public date-key helper exposed for consistent date comparisons across timed and all-day events.

* **Chores**
  * Migrated timezone/date handling to Temporal (polyfill added) for more consistent parsing/formatting and clearer fallbacks.

* **Tests**
  * Added regression test for date-only RRULE normalization; removed an obsolete midnight-edge test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->