### PR TITLE
fix: exclude timed EXDATE instances crossing UTC midnight due to DST

### DIFF
--- a/node-ical.js
+++ b/node-ical.js
@@ -432,7 +432,7 @@ function processRecurringInstance(date, event, options, baseDurationMs) {
           return null;
         }
       }
-    } else if (event.exdate[dateKey]) {
+    } else if (event.exdate[dateKey] || event.exdate[date.toISOString()]) {
       return null;
     }
   }


### PR DESCRIPTION
While implementing `expandRecurringEvent` in MagicMirror I noticed a subtle bug: recurring timed events with an EXDATE weren't always excluded correctly.

The culprit is a DST edge case — when an event's local time crosses UTC midnight (e.g. 16:00 PST = 00:00 UTC the next day), the date-only key from `generateDateKey()` ("2023-11-09") matches neither key stored by the parser ("2023-11-08" local date, or "2023-11-09T00:00:00.000Z" full ISO string).

The fix adds a fallback to the full ISO string lookup, consistent with the dual-key storage already in the parser.

Includes a regression test with a weekly 16:00 America/Los_Angeles event and an EXDATE on the first occurrence after the PDT→PST switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of excluded recurring event instances (EXDATE) by expanding lookup to cover additional key formats, ensuring events are properly excluded even during daylight saving time transitions.

* **Tests**
  * Added test cases validating EXDATE exclusion during UTC midnight crossings caused by DST changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->