### PR TITLE
fix(release): switch to master before creating version bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,14 @@ jobs:
       # The release event checks out the tag (detached HEAD).
       # peter-evans/create-pull-request needs a real branch to work from,
       # so we switch to the default branch and re-apply the version bump there.
+      # Discard the intermediate package.json changes from the earlier
+      # "Set package version" step so that git checkout succeeds.
       - name: Switch to default branch for version bump
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          git checkout ${{ github.event.repository.default_branch }}
+          git restore package.json package-lock.json
+          git checkout "$DEFAULT_BRANCH"
           npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version
 
       - name: Create PR for version bump back to default branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,16 +74,16 @@ jobs:
 
       # The release event checks out the tag (detached HEAD).
       # peter-evans/create-pull-request needs a real branch to work from,
-      # so we switch to master and re-apply the version bump there.
+      # so we switch to the default branch and re-apply the version bump there.
       - name: Switch to default branch for version bump
         run: |
-          git checkout master
+          git checkout ${{ github.event.repository.default_branch }}
           npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version
 
       - name: Create PR for version bump back to default branch
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
-          base: master
+          base: ${{ github.event.repository.default_branch }}
           commit-message: "chore(release): ${{ steps.ver.outputs.version }}"
           title: "chore(release): ${{ steps.ver.outputs.version }}"
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,14 @@ jobs:
       - name: Publish to npm (Trusted Publishing / OIDC)
         run: npm publish --access public
 
+      # The release event checks out the tag (detached HEAD).
+      # peter-evans/create-pull-request needs a real branch to work from,
+      # so we switch to master and re-apply the version bump there.
+      - name: Switch to default branch for version bump
+        run: |
+          git checkout master
+          npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version
+
       - name: Create PR for version bump back to default branch
         uses: peter-evans/create-pull-request@v6
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ical",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "main": "node-ical.js",
   "types": "node-ical.d.ts",
   "description": "NodeJS class for parsing iCalendar/ICS files",


### PR DESCRIPTION
The 0.25.4 release was [published to npm successfully](https://www.npmjs.com/package/node-ical/v/0.25.4), but the automated version bump PR was never created — `package.json` on `master` still says `0.25.3`.

This happened because the release workflow (which I refactored in PR #463) checks out the release **tag**, which results in a detached HEAD. `peter-evans/create-pull-request` then fails with git exit code 128 because it cannot push a branch from a detached state.

**Failed run:** https://github.com/jens-maus/node-ical/actions/runs/22280144048

Sorry for the oversight! This PR fixes it by explicitly switching to `master` after the npm publish step and re-applying `npm version` there, so `create-pull-request` has a proper branch to work from.

Also includes the missing `package.json` bump to `0.25.4`. No new release needed — the published npm package is correct, this just syncs `master` and prevents the issue from recurring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.25.4.
  * Improved release flow to reliably reapply the version bump on the default branch and automatically create a follow-up pull request (branch naming, labels, and auto-delete enabled) to streamline post-release version management and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->