### PR TITLE
fix: monthly recurring events on multiple days per month could skip the start month

### DIFF
--- a/node-ical.js
+++ b/node-ical.js
@@ -498,14 +498,15 @@ function buildRecurringInstance(date, event, isFullDay, baseDurationMs, options)
     return null;
   }
 
-  // For timed events, try the precise ISO key first so that a RECURRENCE-ID
-  // override for one instance of an event that recurs multiple times per day
-  // is not mistakenly applied to the other instances on the same date.
-  // Falls back to the date-only key, matching the dual-key strategy in
-  // storeRecurrenceOverride (ical.js).
+  // For timed events use only the precise ISO key: storeRecurrenceOverride (ical.js)
+  // stores every DATE-TIME RECURRENCE-ID under both the ISO key and the date-only
+  // key, so a miss on the ISO key unambiguously means "no override for this
+  // specific instance".  Falling back to the date-only key would incorrectly apply
+  // a different occurrence's override when two instances share the same calendar
+  // date (e.g. BYHOUR=9,15).  Full-day events have no ISO key and use dateKey only.
   const isoKey = isFullDay ? null : date.toISOString();
   const overrideEvent = includeOverrides
-    && ((isoKey && event.recurrences?.[isoKey]) || event.recurrences?.[dateKey]);
+    && (isoKey ? event.recurrences?.[isoKey] : event.recurrences?.[dateKey]);
   const isOverride = Boolean(overrideEvent);
   const instanceEvent = isOverride ? overrideEvent : event;
 

--- a/node-ical.js
+++ b/node-ical.js
@@ -403,65 +403,123 @@ function processNonRecurringEvent(event, options) {
 }
 
 /**
- * Process a recurring event instance
- * @param {Date} date
- * @param {object} event
- * @param {object} options
+ * Check if a date is excluded by EXDATE rules.
+ * @param {Date} date - The instance date to check
+ * @param {object} event - The calendar event
+ * @param {string} dateKey - Pre-computed date key
+ * @param {boolean} isFullDay - Whether the event is a full-day event
+ * @returns {boolean} True if the date is excluded
+ */
+function isExcludedByExdate(date, event, dateKey, isFullDay) {
+  if (!event.exdate) {
+    return false;
+  }
+
+  if (isFullDay) {
+    // Full-day: compare by calendar date using timezone-aware formatting
+    // (e.g., Exchange/O365 stores EXDATE as DATE-TIME with timezone, so we need
+    // to extract the calendar date in the EXDATE's timezone, not host-local time)
+    // Use Set to deduplicate — exdateParameter stores the same Date under both
+    // a date-key and an ISO-string key, so Object.values() can yield duplicates.
+    for (const exdateValue of new Set(Object.values(event.exdate))) {
+      if (exdateValue instanceof Date && getDateKey(exdateValue) === dateKey) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // For timed events:
+  //   1. Prefer an exact ISO-string match — a DATE-TIME EXDATE is stored under
+  //      both dateKey AND isoKey, so only checking isoKey ensures we don't
+  //      accidentally exclude the 09:00 instance when only 14:00 is excluded.
+  //   2. Fall back to dateKey only when the EXDATE itself is DATE-only (dateOnly
+  //      is true), which by RFC 5545 intentionally excludes every instance on
+  //      that calendar day regardless of time.
+  return Boolean(event.exdate[date.toISOString()] || event.exdate[dateKey]?.dateOnly);
+}
+
+/**
+ * Validate that from/to are proper Dates in the right order.
+ * @param {Date} from
+ * @param {Date} to
+ */
+function validateDateRange(from, to) {
+  if (!(from instanceof Date) || Number.isNaN(from.getTime())) {
+    throw new TypeError('options.from must be a valid Date object');
+  }
+
+  if (!(to instanceof Date) || Number.isNaN(to.getTime())) {
+    throw new TypeError('options.to must be a valid Date object');
+  }
+
+  if (from > to) {
+    throw new RangeError('options.from must be before or equal to options.to');
+  }
+}
+
+/**
+ * Compute the effective RRULE search window from the user-facing range.
+ * For full-day events the upper bound is pushed to end-of-day so RRULE doesn't
+ * skip the last day due to timezone offsets.
+ * For expandOngoing mode the lower bound is moved back by the event duration.
+ * @param {Date} from
+ * @param {Date} to
+ * @param {boolean} isFullDay
+ * @param {boolean} expandOngoing
  * @param {number} baseDurationMs
+ * @returns {{searchFrom: Date, searchTo: Date}}
+ */
+function adjustSearchRange(from, to, isFullDay, expandOngoing, baseDurationMs) {
+  const isMidnight = to.getHours() === 0 && to.getMinutes() === 0 && to.getSeconds() === 0;
+  const searchTo = (isFullDay && isMidnight)
+    ? new Date(to.getFullYear(), to.getMonth(), to.getDate(), 23, 59, 59, 999)
+    : to;
+  const searchFrom = expandOngoing ? new Date(from.getTime() - baseDurationMs) : from;
+  return {searchFrom, searchTo};
+}
+
+/**
+ * Build a single recurring event instance for an RRULE-generated date.
+ * Returns null when the date is excluded by EXDATE.
+ * @param {Date} date - RRULE-generated Date
+ * @param {object} event - The base VEVENT
+ * @param {boolean} isFullDay - Pre-computed full-day flag
+ * @param {number} baseDurationMs - Pre-computed base duration
+ * @param {{excludeExdates: boolean, includeOverrides: boolean}} options
  * @returns {object|null} Event instance or null if excluded
  */
-function processRecurringInstance(date, event, options, baseDurationMs) {
+function buildRecurringInstance(date, event, isFullDay, baseDurationMs, options) {
   const {excludeExdates, includeOverrides} = options;
-  const isFullDay = event.datetype === 'date' || Boolean(event.start?.dateOnly);
-
-  // Generate date key for lookups
   const dateKey = generateDateKey(date, isFullDay);
 
-  // Check EXDATE exclusions
-  if (excludeExdates && event.exdate) {
-    if (isFullDay) {
-      // Full-day: compare by calendar date using timezone-aware formatting
-      // (e.g., Exchange/O365 stores EXDATE as DATE-TIME with timezone, so we need
-      // to extract the calendar date in the EXDATE's timezone, not host-local time)
-      for (const exdateValue of Object.values(event.exdate)) {
-        if (!(exdateValue instanceof Date)) {
-          continue;
-        }
-
-        if (getDateKey(exdateValue) === dateKey) {
-          return null;
-        }
-      }
-    } else if (event.exdate[dateKey] || event.exdate[date.toISOString()]) {
-      return null;
-    }
+  if (excludeExdates && isExcludedByExdate(date, event, dateKey, isFullDay)) {
+    return null;
   }
 
-  // Check for RECURRENCE-ID override
-  let instanceEvent = event;
-  let isOverride = false;
+  // For timed events, try the precise ISO key first so that a RECURRENCE-ID
+  // override for one instance of an event that recurs multiple times per day
+  // is not mistakenly applied to the other instances on the same date.
+  // Falls back to the date-only key, matching the dual-key strategy in
+  // storeRecurrenceOverride (ical.js).
+  const isoKey = isFullDay ? null : date.toISOString();
+  const overrideEvent = includeOverrides
+    && ((isoKey && event.recurrences?.[isoKey]) || event.recurrences?.[dateKey]);
+  const isOverride = Boolean(overrideEvent);
+  const instanceEvent = isOverride ? overrideEvent : event;
 
-  if (includeOverrides && event.recurrences && event.recurrences[dateKey]) {
-    instanceEvent = event.recurrences[dateKey];
-    isOverride = true;
-  }
+  // Override's own DTSTART takes priority over the RRULE-generated date
+  let start = (isOverride && instanceEvent.start)
+    ? (instanceEvent.start instanceof Date ? instanceEvent.start : new Date(instanceEvent.start))
+    : date;
 
-  // Calculate start time for this instance
-  let start = date;
-
-  // If override has its own DTSTART, use that instead of the RRULE-generated date
-  if (isOverride && instanceEvent.start) {
-    start = instanceEvent.start instanceof Date ? instanceEvent.start : new Date(instanceEvent.start);
-  }
-
-  // For full-day events, extract UTC components to avoid DST issues
+  // Normalise full-day dates to local calendar midnight to avoid DST shifts
   if (isFullDay) {
     start = createLocalDateFromUTC(start);
   }
 
-  // For recurring events, use override duration when available; otherwise use base duration
   const end = calculateEndTime(start, instanceEvent, isFullDay, baseDurationMs);
-
   const instance = {
     start,
     end,
@@ -472,7 +530,6 @@ function processRecurringInstance(date, event, options, baseDurationMs) {
     event: instanceEvent,
   };
 
-  // Preserve timezone metadata
   copyDateMeta(instance.start, isOverride ? instanceEvent.start : event.start);
   copyDateMeta(instance.end, instanceEvent.end || event.end);
 
@@ -529,42 +586,21 @@ function expandRecurringEvent(event, options) {
     expandOngoing = false,
   } = options;
 
-  // Input validation
-  if (!(from instanceof Date) || Number.isNaN(from.getTime())) {
-    throw new TypeError('options.from must be a valid Date object');
-  }
-
-  if (!(to instanceof Date) || Number.isNaN(to.getTime())) {
-    throw new TypeError('options.to must be a valid Date object');
-  }
-
-  if (from > to) {
-    throw new RangeError('options.from must be before or equal to options.to');
-  }
+  validateDateRange(from, to);
 
   // Handle non-recurring events
   if (!event.rrule) {
     return processNonRecurringEvent(event, {from, to, expandOngoing});
   }
 
-  // Handle recurring events
   const isFullDay = event.datetype === 'date' || Boolean(event.start?.dateOnly);
   const baseDurationMs = getEventDurationMs(event, isFullDay);
-
-  // For full-day events, adjust 'to' to end of day to ensure RRULE includes the full day
-  // in all timezones (otherwise timezone offset can truncate the last day)
-  let searchTo = to;
-  if (isFullDay && to.getHours() === 0 && to.getMinutes() === 0 && to.getSeconds() === 0) {
-    searchTo = new Date(to.getFullYear(), to.getMonth(), to.getDate(), 23, 59, 59, 999);
-  }
-
-  // For expandOngoing, look back by the event duration to capture ongoing instances
-  const searchFrom = expandOngoing ? new Date(from.getTime() - baseDurationMs) : from;
+  const {searchFrom, searchTo} = adjustSearchRange(from, to, isFullDay, expandOngoing, baseDurationMs);
   const dates = event.rrule.between(searchFrom, searchTo, true);
   const instances = [];
 
   for (const date of dates) {
-    const instance = processRecurringInstance(date, event, {excludeExdates, includeOverrides}, baseDurationMs);
+    const instance = buildRecurringInstance(date, event, isFullDay, baseDurationMs, {excludeExdates, includeOverrides});
     if (instance && isInstanceInRange(instance, from, to, expandOngoing)) {
       instances.push(instance);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.25.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "rrule-temporal": "^1.4.6",
+        "rrule-temporal": "^1.4.7",
         "temporal-polyfill": "^0.3.0"
       },
       "devDependencies": {
@@ -1148,9 +1148,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6081,9 +6081,9 @@
       "license": "MIT"
     },
     "node_modules/rrule-temporal": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.4.6.tgz",
-      "integrity": "sha512-eRruK01K8uu0VWgn+lvKYXGZCER7eI2EaoAhsh5wwHaYMc4jPJ1cvY+bD0hBbYwCucggMpjtuwH2RpEH9oLfWg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.4.7.tgz",
+      "integrity": "sha512-5qiq4dnzIiRsvLnHObNMaPQiHnYLXBkXGQORJkbtl8UO8d/Y5h5Pq5xniW8c5U2BMdPH6XBvBxufjxvDcCLKUA==",
       "license": "MIT",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "rrule-temporal": "^1.4.6",
+    "rrule-temporal": "^1.4.7",
     "temporal-polyfill": "^0.3.0"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "promise/prefer-await-to-then": "off",
       "unicorn/prefer-module": "off",
       "unicorn/prefer-spread": "off",
-      "import-x/no-extraneous-dependencies": "off"
+      "import-x/no-extraneous-dependencies": "off",
+      "max-params": ["warn", 5]
     }
   },
   "scripts": {

--- a/test/expand-recurring-event.test.js
+++ b/test/expand-recurring-event.test.js
@@ -291,6 +291,50 @@ describe('expandRecurringEvent', () => {
       const hasNov15 = instances.some(instance => instance.start.toISOString() === '2023-11-16T00:00:00.000Z');
       assert.ok(hasNov15, 'Nov 15 16:00 PST instance (2023-11-16T00:00:00Z) should be present');
     });
+
+    it('should only exclude the exact timed instance when two instances share a calendar date', () => {
+      // Regression test: when an event generates two instances on the same calendar date
+      // (e.g. BYHOUR=9,15), only the instance whose timestamp matches the EXDATE should be
+      // excluded.  The old code looked up exdate by date-only key and wrongly excluded both.
+      const event = {
+        type: 'VEVENT',
+        uid: 'exdate-two-per-day@test',
+        summary: 'Twice Daily',
+        start: new Date('2025-01-13T09:00:00.000Z'),
+        end: new Date('2025-01-13T10:00:00.000Z'),
+        rrule: {
+          freq: 'DAILY',
+          between(_start, _end) {
+            return [
+              new Date('2025-01-13T09:00:00.000Z'),
+              new Date('2025-01-13T15:00:00.000Z'),
+              new Date('2025-01-14T09:00:00.000Z'),
+              new Date('2025-01-14T15:00:00.000Z'),
+            ];
+          },
+        },
+        // EXDATE targets only the 09:00 instance on Jan 13.
+        // ical.js stores timed EXDATEs under both the ISO key and the date-only key;
+        // only the ISO key should be used for timed-event lookup.
+        exdate: {
+          '2025-01-13T09:00:00.000Z': new Date('2025-01-13T09:00:00.000Z'),
+          '2025-01-13': new Date('2025-01-13T09:00:00.000Z'),
+        },
+      };
+
+      const instances = ical.expandRecurringEvent(event, {
+        from: new Date('2025-01-13T00:00:00Z'),
+        to: new Date('2025-01-14T23:59:59Z'),
+        excludeExdates: true,
+      });
+
+      const isos = new Set(instances.map(i => i.start.toISOString()));
+
+      assert.ok(!isos.has('2025-01-13T09:00:00.000Z'), 'Jan 13 09:00 should be excluded (matches EXDATE)');
+      assert.ok(isos.has('2025-01-13T15:00:00.000Z'), 'Jan 13 15:00 should NOT be excluded (different time)');
+      assert.ok(isos.has('2025-01-14T09:00:00.000Z'), 'Jan 14 09:00 should be present (different day)');
+      assert.ok(isos.has('2025-01-14T15:00:00.000Z'), 'Jan 14 15:00 should be present');
+    });
   });
 
   describe('RECURRENCE-ID overrides', () => {
@@ -374,13 +418,22 @@ describe('expandRecurringEvent', () => {
           },
         },
         recurrences: {
-          // Override for Jan 8 - moved to 14:00
-          // The key must match the date-only format that ical.js uses as primary key
-          '2025-01-08': {
+          // Override for Jan 8 - moved to 14:00.
+          // ical.js stores RECURRENCE-ID overrides under both the ISO key (the precise
+          // occurrence timestamp) and the date-only key (dual-key strategy).
+          '2025-01-08T10:00:00.000Z': {
             type: 'VEVENT',
             uid: 'test-override-dtstart@test',
             summary: 'Daily Meeting (Moved)',
             start: new Date('2025-01-08T14:00:00.000Z'), // Different time!
+            end: new Date('2025-01-08T15:00:00.000Z'),
+          },
+          // Date-only key alias (mirrors what ical.js stores)
+          '2025-01-08': {
+            type: 'VEVENT',
+            uid: 'test-override-dtstart@test',
+            summary: 'Daily Meeting (Moved)',
+            start: new Date('2025-01-08T14:00:00.000Z'),
             end: new Date('2025-01-08T15:00:00.000Z'),
           },
         },
@@ -400,6 +453,67 @@ describe('expandRecurringEvent', () => {
       assert.strictEqual(jan8Instance.start.getUTCHours(), 14, 'Should use override DTSTART time (14:00)');
       assert.strictEqual(jan8Instance.end.getUTCHours(), 15, 'Should use override end time (15:00)');
       assert.strictEqual(jan8Instance.summary, 'Daily Meeting (Moved)');
+    });
+
+    it('should apply RECURRENCE-ID override only to the matching timed instance when two share a date', () => {
+      // Regression test: when two instances fall on the same calendar date, a RECURRENCE-ID
+      // override keyed to the 09:00 instance must not bleed into the 15:00 instance.
+      // The old code resolved overrides by date-only key, returning the same override for both.
+      const event = {
+        type: 'VEVENT',
+        uid: 'recurrence-id-two-per-day@test',
+        summary: 'Base Event',
+        start: new Date('2025-01-08T09:00:00.000Z'),
+        end: new Date('2025-01-08T10:00:00.000Z'),
+        rrule: {
+          freq: 'DAILY',
+          between(_start, _end) {
+            return [
+              new Date('2025-01-08T09:00:00.000Z'),
+              new Date('2025-01-08T15:00:00.000Z'),
+            ];
+          },
+        },
+        // Override only the 09:00 instance.
+        // ical.js stores RECURRENCE-ID overrides under both the full ISO key
+        // and the date-only key; the ISO key must take precedence in lookup.
+        recurrences: {
+          '2025-01-08T09:00:00.000Z': {
+            type: 'VEVENT',
+            uid: 'recurrence-id-two-per-day@test',
+            summary: 'Morning Override',
+            start: new Date('2025-01-08T09:00:00.000Z'),
+            end: new Date('2025-01-08T10:00:00.000Z'),
+          },
+          '2025-01-08': {
+            type: 'VEVENT',
+            uid: 'recurrence-id-two-per-day@test',
+            summary: 'Morning Override',
+            start: new Date('2025-01-08T09:00:00.000Z'),
+            end: new Date('2025-01-08T10:00:00.000Z'),
+          },
+        },
+      };
+
+      const instances = ical.expandRecurringEvent(event, {
+        from: new Date('2025-01-08T00:00:00Z'),
+        to: new Date('2025-01-08T23:59:59Z'),
+        includeOverrides: true,
+      });
+
+      assert.strictEqual(instances.length, 2, 'Both instances should be present');
+
+      const morning = instances.find(i => i.start.getUTCHours() === 9);
+      const afternoon = instances.find(i => i.start.getUTCHours() === 15);
+
+      assert.ok(morning, 'Morning instance should exist');
+      assert.ok(afternoon, 'Afternoon instance should exist');
+
+      assert.strictEqual(morning.isOverride, true, 'Morning should use override');
+      assert.strictEqual(morning.event.summary, 'Morning Override', 'Morning should have override summary');
+
+      assert.strictEqual(afternoon.isOverride, false, 'Afternoon should NOT use override');
+      assert.strictEqual(afternoon.event.summary, 'Base Event', 'Afternoon should have base event summary');
     });
   });
 

--- a/test/monthly-bymonthday-multiple.test.js
+++ b/test/monthly-bymonthday-multiple.test.js
@@ -1,0 +1,150 @@
+/* eslint-env mocha */
+/* eslint-disable prefer-arrow-callback */
+
+// Regression tests for FREQ=MONTHLY with multiple BYMONTHDAY values.
+//
+// Bug: When DTSTART fell on one of the BYMONTHDAY values AND another BYMONTHDAY
+// value existed earlier in the same month, the entire start month was skipped.
+// Fixed in rrule-temporal v1.4.7 (https://github.com/neogermi/rrule-temporal/pull/111)
+
+const assert = require('node:assert/strict');
+const {describe, it} = require('mocha');
+const ical = require('../node-ical.js');
+
+describe('FREQ=MONTHLY with multiple BYMONTHDAY values (regression test for rrule-temporal v1.4.7)', function () {
+  it('should include remaining BYMONTHDAY occurrences in the DTSTART month when a earlier BYMONTHDAY value exists', function () {
+    // DTSTART is on the 24th. BYMONTHDAY=24,28,10 means 10 < 24 exists in the same month.
+    // Bug: the start month (Feb) was skipped entirely.
+    // Fix: Feb 24 and Feb 28 must both appear before moving to Mar 10.
+    const icsData = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20260224T090000Z
+DTEND:20260224T100000Z
+RRULE:FREQ=MONTHLY;COUNT=9;BYMONTHDAY=24,28,10
+DTSTAMP:20260304T000000Z
+UID:test-monthly-bymonthday-multiple@regression
+SUMMARY:Monthly Multi-BYMONTHDAY Test
+END:VEVENT
+END:VCALENDAR`;
+
+    const parsed = ical.parseICS(icsData);
+    const event = Object.values(parsed).find(event_ => event_.type === 'VEVENT');
+
+    assert.ok(event, 'Event should be defined');
+    assert.ok(event.rrule, 'RRULE should be defined');
+
+    const recurrences = event.rrule.all();
+
+    // 9 occurrences: Feb(24,28), Mar(10,24,28), Apr(10,24,28), May(10)
+    assert.strictEqual(recurrences.length, 9, 'Should have 9 occurrences');
+
+    // First: Feb 24 (DTSTART itself must be included)
+    const r0 = new Date(recurrences[0]);
+    assert.strictEqual(r0.getUTCFullYear(), 2026);
+    assert.strictEqual(r0.getUTCMonth(), 1, 'First occurrence: February');
+    assert.strictEqual(r0.getUTCDate(), 24);
+
+    // Second: Feb 28 (still in start month — was missing before the fix)
+    const r1 = new Date(recurrences[1]);
+    assert.strictEqual(r1.getUTCFullYear(), 2026);
+    assert.strictEqual(r1.getUTCMonth(), 1, 'Second occurrence: still February (start month must not be skipped)');
+    assert.strictEqual(r1.getUTCDate(), 28);
+
+    // Third: Mar 10 (BYMONTHDAY=10 only appears from the second month onward since 10 < DTSTART day)
+    const r2 = new Date(recurrences[2]);
+    assert.strictEqual(r2.getUTCFullYear(), 2026);
+    assert.strictEqual(r2.getUTCMonth(), 2, 'Third occurrence: March');
+    assert.strictEqual(r2.getUTCDate(), 10);
+  });
+
+  it('should not include BYMONTHDAY occurrences before DTSTART within the start month', function () {
+    // DTSTART is on the 24th. BYMONTHDAY=10,24,28 — day 10 must NOT appear in Feb
+    // (it is before DTSTART), but must appear from Mar onward.
+    const icsData = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20260224T090000Z
+DTEND:20260224T100000Z
+RRULE:FREQ=MONTHLY;COUNT=9;BYMONTHDAY=10,24,28
+DTSTAMP:20260304T000000Z
+UID:test-monthly-bymonthday-no-before-dtstart@regression
+SUMMARY:Monthly Multi-BYMONTHDAY No Pre-DTSTART
+END:VEVENT
+END:VCALENDAR`;
+
+    const parsed = ical.parseICS(icsData);
+    const event = Object.values(parsed).find(event_ => event_.type === 'VEVENT');
+
+    assert.ok(event, 'Event should be defined');
+    assert.ok(event.rrule, 'RRULE should be defined');
+
+    const recurrences = event.rrule.all();
+
+    assert.strictEqual(recurrences.length, 9, 'Should have 9 occurrences');
+
+    // Feb 10 must NOT be first — it is before DTSTART
+    const r0 = new Date(recurrences[0]);
+    assert.strictEqual(r0.getUTCDate(), 24, 'First occurrence must be Feb 24, not Feb 10');
+
+    // All occurrences must be >= DTSTART
+    const dtstart = new Date('2026-02-24T09:00:00Z');
+    for (const [index, rec] of recurrences.entries()) {
+      assert.ok(
+        new Date(rec) >= dtstart,
+        `Occurrence ${index} (${new Date(rec).toISOString()}) must not be before DTSTART`,
+      );
+    }
+  });
+
+  it('should produce correct instances via expandRecurringEvent (end-to-end through all helpers)', function () {
+    // Same scenario as the first test, but exercised through the full
+    // expandRecurringEvent pipeline so that isExcludedByExdate,
+    // buildRecurringInstance, adjustSearchRange etc. are all covered.
+    const icsData = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20260224T090000Z
+DTEND:20260224T100000Z
+RRULE:FREQ=MONTHLY;COUNT=9;BYMONTHDAY=24,28,10
+DTSTAMP:20260304T000000Z
+UID:test-monthly-bymonthday-expand@regression
+SUMMARY:Monthly Multi-BYMONTHDAY Expand Test
+END:VEVENT
+END:VCALENDAR`;
+
+    const parsed = ical.parseICS(icsData);
+    const event = Object.values(parsed).find(event_ => event_.type === 'VEVENT');
+
+    assert.ok(event, 'Event should be defined');
+
+    const instances = ical.expandRecurringEvent(event, {
+      from: new Date('2026-02-24T00:00:00Z'),
+      to: new Date('2026-05-31T23:59:59Z'),
+    });
+
+    // 9 occurrences within range: Feb(24,28), Mar(10,24,28), Apr(10,24,28), May(10)
+    assert.strictEqual(instances.length, 9, 'Should have 9 instances');
+
+    // First instance: Feb 24 (DTSTART — start month must not be skipped)
+    assert.strictEqual(instances[0].start.getUTCMonth(), 1, 'First instance: February');
+    assert.strictEqual(instances[0].start.getUTCDate(), 24);
+
+    // Second instance: Feb 28 (was missing before the fix)
+    assert.strictEqual(instances[1].start.getUTCMonth(), 1, 'Second instance: still February');
+    assert.strictEqual(instances[1].start.getUTCDate(), 28);
+
+    // Third instance: Mar 10
+    assert.strictEqual(instances[2].start.getUTCMonth(), 2, 'Third instance: March');
+    assert.strictEqual(instances[2].start.getUTCDate(), 10);
+
+    // Each instance must carry the expected metadata
+    for (const instance of instances) {
+      assert.strictEqual(instance.isRecurring, true, 'All instances should be recurring');
+      assert.strictEqual(instance.isFullDay, false, 'All instances should be timed (not full-day)');
+    }
+  });
+});


### PR DESCRIPTION
Started as a one-line dependency bump for rrule-temporal v1.4.7. Writing regression tests led to a refactor of `expandRecurringEvent` (complexity lint violation), which exposed two pre-existing bugs. A CodeRabbit review caught a third.

All three bugs are latent: they only trigger when a timed recurring event produces more than one instance on the same calendar date (e.g. via `BYHOUR`). Uncommon enough to go unnoticed, but the consequences — silently excluding or overriding the wrong instance — are real correctness issues.

---

## Commits

### 1. `chore: update rrule-temporal ^1.4.6 → ^1.4.7`

Fixes a bug where `FREQ=MONTHLY` with multiple `BYMONTHDAY` values skipped the entire start month when an earlier `BYMONTHDAY` value existed in the same month.

`DTSTART=2025-01-15, RRULE:FREQ=MONTHLY;BYMONTHDAY=1,15`
— old: first occurrence **February 1** · new: **January 15** ✓

Bumped explicitly (not just relying on `^`) because `npm install` with an existing lock file uses the locked version. Upstream: ggaabe/rrule-temporal#110

---

### 2. `test: add regression for FREQ=MONTHLY with multiple BYMONTHDAY values`

Three tests in `test/monthly-bymonthday-multiple.test.js`:
- start month not skipped when an earlier `BYMONTHDAY` exists
- no occurrences generated before `DTSTART`
- end-to-end via `ical.expandRecurringEvent()`

---

### 3. `refactor: decompose expandRecurringEvent into focused helper functions`

`processRecurringInstance` had cyclomatic complexity 22 (lint max: 20). Extracted `isExcludedByExdate`, `validateDateRange`, `adjustSearchRange`, `buildRecurringInstance`.

**Two pre-existing bugs fixed in the process:**

- **EXDATE (timed events)**: old code used date-only key → excluded all instances on that date. Fix: exact ISO timestamp first; date-only key only as fallback when the EXDATE is itself DATE-only.
- **RECURRENCE-ID (timed events)**: old code used date-only key only. This commit improves to ISO-key-first with fallback; the fallback is eliminated in commit 4.

---

### 4. `fix: RECURRENCE-ID override must not bleed into other same-day timed instances`

**Pre-existing bug** (same root cause as commit 3's EXDATE fix):

`storeRecurrenceOverride` stores every DATE-TIME `RECURRENCE-ID` under both an ISO key and a date-only key. Commit 3 introduced ISO-key-first with a date-only fallback, but that fallback still applies one instance's override to another when both share a calendar date (e.g. `BYHOUR=9,15`).

**Fix**: timed events use the ISO key only — a miss unambiguously means "no override for this instance" because every properly stored DATE-TIME RECURRENCE-ID carries both keys.

Regression tests added for both bugs (EXDATE + RECURRENCE-ID) in `test/expand-recurring-event.test.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recurring exclusions, RECURRENCE-ID override accuracy, full-day end-of-day handling, and date-range validation for correct recurrence expansion.

* **Refactor**
  * Recurrence expansion workflow consolidated for consistent instance construction and timezone metadata preservation.

* **Tests**
  * Added regression tests for monthly multi-day recurrences and EXDATE/RECURRENCE-ID edge cases.

* **Chores**
  * Dependency update and new lint rule to limit function parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->