### PR TITLE
ci: update Node.js version matrix + drop Node 20 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "xo": "^3.0.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/jens-maus/node-ical.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "rrule-temporal": "^1.5.3",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the automated test workflow to run against an additional Node.js version (Node 26.x) alongside the existing supported Node.js versions.
  * Automated testing now validates compatibility with newer runtime environments while preserving current test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->