### PR TITLE
fix: move to rrule-temporal v2 and drop the @js-temporal override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.26.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "rrule-temporal": "^1.5.3",
+        "rrule-temporal": "^2.0.0",
         "temporal-polyfill": "^0.3.2"
       },
       "devDependencies": {
@@ -1084,22 +1084,6 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
-    },
-    "node_modules/@js-temporal/polyfill": {
-      "name": "temporal-polyfill",
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "temporal-spec": "0.3.1"
-      }
-    },
-    "node_modules/@js-temporal/polyfill/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -6494,13 +6478,15 @@
       "license": "MIT"
     },
     "node_modules/rrule-temporal": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.6.0.tgz",
-      "integrity": "sha512-tlhiNroletItRVdVP3knk92MCPNdFmPpehQMxf+jSo0CHZpmp1WUsvdVpg2iS++J9+O7/89J64BldN21kbcBqA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-2.0.0.tgz",
+      "integrity": "sha512-gKYHKNXiQ7G6eiv+y2FKF5AaXp7LTBhG2HM+tHqh3FufRD7vGMpmjaVjjJqN42UfDQjVBGS0aTS1NKcIEtDo+A==",
       "license": "MIT",
       "dependencies": {
-        "@js-temporal/polyfill": "^0.5.1",
         "temporal-spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/run-applescript": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,8 @@
     "node": ">=22"
   },
   "dependencies": {
-    "rrule-temporal": "^1.5.3",
+    "rrule-temporal": "^2.0.0",
     "temporal-polyfill": "^0.3.2"
-  },
-  "overrides": {
-    "@js-temporal/polyfill": "npm:temporal-polyfill@^0.3.0"
   },
   "devDependencies": {
     "date-fns": "^4.4.0",

--- a/test/polyfill-check.test.js
+++ b/test/polyfill-check.test.js
@@ -1,10 +1,6 @@
 import assert from 'node:assert/strict';
 import {execSync} from 'node:child_process';
-import {createRequire} from 'node:module';
-import path from 'node:path';
 import {describe, it} from 'mocha';
-
-const require = createRequire(import.meta.url);
 
 describe('Temporal Polyfill Configuration', () => {
   it('should NOT have JSBI dependency installed', () => {
@@ -15,28 +11,5 @@ describe('Temporal Polyfill Configuration', () => {
       // Expected: JSBI should not be found (command will fail)
       assert.ok(true, 'JSBI is not installed as expected');
     }
-  });
-
-  it('should use temporal-polyfill (not @js-temporal/polyfill with JSBI)', () => {
-    const result = execSync('npm ls @js-temporal/polyfill --json', {encoding: 'utf8'});
-    const data = JSON.parse(result);
-
-    // Find the actual resolved package
-    const resolved = data.dependencies['rrule-temporal'].dependencies['@js-temporal/polyfill'];
-
-    assert.ok(resolved, '@js-temporal/polyfill should be resolved');
-    assert.match(resolved.resolved, /temporal-polyfill/v);
-  });
-
-  it('should load temporal-polyfill when requiring @js-temporal/polyfill', () => {
-    // Clear require cache to force fresh load
-    const modulePath = require.resolve('@js-temporal/polyfill');
-    delete require.cache[modulePath];
-
-    const _Temporal = require('@js-temporal/polyfill');
-    const packageJsonPath = path.join(path.dirname(modulePath), 'package.json');
-    const packageJson = require(packageJsonPath);
-
-    assert.strictEqual(packageJson.name, 'temporal-polyfill');
   });
 });


### PR DESCRIPTION
`rrule-temporal` v2.0.0 dropped `@js-temporal/polyfill`, so the `overrides` entry from #442 has nothing left to redirect.

As #524 explains, `overrides` only applies at the root project, so consumers kept resolving `@js-temporal/polyfill` and `jsbi` regardless – this drops both from their trees, not only from this repo's.

- `rrule-temporal` `^1.5.3` -> `^2.0.0`
- `overrides` removed
- Dropped the two `test/polyfill-check.test.js` cases asserting that `@js-temporal/polyfill` resolves to `temporal-polyfill` – it is no longer in the tree at all. The JSBI check stays and now passes on its own terms

195 -> 193 tests, green on Node 22, 24 and 26. `test:types` and `xo` clean.

I have not touched v2's other breaking changes (`all()` memoization, and `next()`/`previous()` now starting near the query point rather than at `DTSTART`). No test here depends on either, but they do change behaviour for anyone relying on the old iteration semantics.

Fixes #524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the recurring-rules package to a newer major version.

* **Tests**
  * Simplified compatibility checks while continuing to verify that the unnecessary `jsbi` package is not installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->