### PR TITLE
chore: align Node.js targets

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,6 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with target in build-cjs.js and engines.node in package.json
         node-version: [22.x, 24.x, 26.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ ical.fromURL(url, options, function(err, data) {
 });
 ```
 
-Fetch the specified URL using the native fetch API (```options``` are passed to the underlying `fetch()` call) and call the function with the result (either an error or the data). Requires Node.js 20+ (or any environment that provides a global `fetch`).
+Fetch the specified URL using the native fetch API (`options` are passed to the underlying `fetch()` call) and call the function with the result (either an error or the data).
 
 #### Example: Print list of upcoming node conferences
 

--- a/build/build-cjs.js
+++ b/build/build-cjs.js
@@ -12,7 +12,8 @@ await build({
   bundle: true,
   platform: 'node',
   format: 'cjs',
-  target: 'node20',
+  // Keep in sync with engines.node in package.json and node-version in .github/workflows/nodejs.yml
+  target: 'node22',
   // Keep node_modules dependencies as require() calls; only bundle our own code
   // (and inline windowsZones.json, which is imported relatively).
   packages: 'external',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `fromURL` example to clarify its use of the native `fetch` API and supported options.

* **Chores**
  * Updated the CommonJS build target to Node.js 22.
  * Added a CI note documenting required version alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->