### PR TITLE
fix(deps): update temporal-polyfill to v1 and fix CJS build

### DIFF
--- a/build/build-cjs.js
+++ b/build/build-cjs.js
@@ -1,9 +1,9 @@
 // Generate the CommonJS entry point (node-ical.cjs) from the ESM sources.
 //
 // ESM (*.js, type: module) is the single source of truth. This bundles
-// node-ical.js into a single self-contained CommonJS file so that
-// `require('node-ical')` keeps working, while runtime dependencies stay
-// external `require()` calls.
+// node-ical.js into a single CommonJS file so that `require('node-ical')` keeps
+// working. The Temporal polyfill is bundled because its v1 package is ESM-only;
+// rrule-temporal remains an external runtime dependency.
 import {build} from 'esbuild';
 
 await build({
@@ -14,8 +14,6 @@ await build({
   format: 'cjs',
   // Keep in sync with engines.node in package.json and node-version in .github/workflows/nodejs.yml
   target: 'node22',
-  // Keep node_modules dependencies as require() calls; only bundle our own code
-  // (and inline windowsZones.json, which is imported relatively).
-  packages: 'external',
+  external: ['rrule-temporal', 'rrule-temporal/totext'],
   logLevel: 'info',
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "rrule-temporal": "^2.0.0",
-        "temporal-polyfill": "^0.3.2"
+        "temporal-polyfill": "^1.0.1"
       },
       "devDependencies": {
         "date-fns": "^4.4.0",
@@ -1760,6 +1760,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1774,6 +1777,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,6 +1794,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1802,6 +1811,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1816,6 +1828,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1830,6 +1845,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1844,6 +1862,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1858,6 +1879,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6994,25 +7018,26 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "0.3.1"
+        "temporal-spec": "1.0.0",
+        "temporal-utils": "1.0.1"
       }
-    },
-    "node_modules/temporal-polyfill/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
     },
     "node_modules/temporal-spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
       "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "rrule-temporal": "^2.0.0",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^1.0.1"
   },
   "devDependencies": {
     "date-fns": "^4.4.0",

--- a/test/polyfill-check.test.js
+++ b/test/polyfill-check.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {execSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
 import {describe, it} from 'mocha';
 
 describe('Temporal Polyfill Configuration', () => {
@@ -11,5 +12,21 @@ describe('Temporal Polyfill Configuration', () => {
       // Expected: JSBI should not be found (command will fail)
       assert.ok(true, 'JSBI is not installed as expected');
     }
+  });
+
+  it('should use temporal-polyfill v1 as a direct dependency', () => {
+    // Read the installed package's own package.json directly instead of
+    // shelling out to `npm ls`, which can exit non-zero (and make execSync
+    // throw) for unrelated dependency-tree issues.
+    const packageJsonUrl = new URL('../node_modules/temporal-polyfill/package.json', import.meta.url);
+    const {version} = JSON.parse(readFileSync(packageJsonUrl, 'utf8'));
+
+    assert.match(String(version), /^1\./v);
+  });
+
+  it('should load temporal-polyfill via ESM import', async () => {
+    const mod = await import('temporal-polyfill');
+
+    assert.ok(mod.Temporal, 'temporal-polyfill should expose Temporal');
   });
 });


### PR DESCRIPTION
The new `temporal-polyfill` v1 release dropped CJS support, which broke the CJS build (ERR_PACKAGE_PATH_NOT_EXPORTED). I fixed it by bundling it into node-ical.cjs instead of leaving it external. rrule-temporal stays external.

No user-facing changes - public API (Date objects, CJS/ESM entry points) stays the same. v1 does bring the polyfill up to the latest Temporal spec with a few DST/duration edge-case fixes upstream.

Also added tests so this doesn't regress silently again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for CommonJS environments when using Temporal-based recurrence features by adjusting how the Temporal polyfill is provided at runtime.
  - Updated the Temporal polyfill dependency to a newer version to improve load-time reliability.

- **Tests**
  - Added checks to confirm the Temporal polyfill is installed at the expected major version.
  - Added coverage to verify the polyfill can be dynamically loaded and exposes the expected Temporal export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->