### PR TITLE
fix(rrule): prevent DATE-only events from dropping when UNTIL contains a UTC timestamp with positive offset (e.g. Outlook exports)

### DIFF
--- a/lib/ical-parser-utils.js
+++ b/lib/ical-parser-utils.js
@@ -430,7 +430,7 @@ function normalizeRruleUntil(rruleOnly, startDate, tzUtil) {
       const dtstartTime = Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
 
       // If UTC UNTIL is within 24h before dtstart due to timezone crossing midnight:
-      const normalizedDate = (utcTimestamp < dtstartTime && (dtstartTime - utcTimestamp) <= 86_400_000)
+      const normalizedDate = (utcTimestamp < dtstartTime && (dtstartTime - utcTimestamp) < 86_400_000)
         ? buildDateOnlyStamp(startDate)
         : datePart;
       return rruleOnly.slice(0, untilStart) + `UNTIL=${normalizedDate}` + rruleOnly.slice(untilEnd);

--- a/lib/ical-parser-utils.js
+++ b/lib/ical-parser-utils.js
@@ -417,6 +417,25 @@ function normalizeRruleUntil(rruleOnly, startDate, tzUtil) {
   const untilEnd = untilStart + untilMatch[0].length;
 
   if (startDate.dateOnly) {
+    if (timePart && zSuffix) {
+      // When UNTIL is in UTC (e.g. from Outlook: UNTIL=20261019T230000Z for DTSTART=20261020),
+      // the UTC timestamp reflects midnight in the creator's positive-offset timezone.
+      const year = Number(datePart.slice(0, 4));
+      const monthIndex = Number(datePart.slice(4, 6)) - 1;
+      const day = Number(datePart.slice(6, 8));
+      const hours = Number(timePart.slice(1, 3));
+      const minutes = Number(timePart.slice(3, 5));
+      const seconds = Number(timePart.slice(5, 7));
+      const utcTimestamp = Date.UTC(year, monthIndex, day, hours, minutes, seconds);
+      const dtstartTime = Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+
+      // If UTC UNTIL is within 24h before dtstart due to timezone crossing midnight:
+      const normalizedDate = (utcTimestamp < dtstartTime && (dtstartTime - utcTimestamp) <= 86_400_000)
+        ? buildDateOnlyStamp(startDate)
+        : datePart;
+      return rruleOnly.slice(0, untilStart) + `UNTIL=${normalizedDate}` + rruleOnly.slice(untilEnd);
+    }
+
     if (timePart) {
       return rruleOnly.slice(0, untilStart) + `UNTIL=${datePart}` + rruleOnly.slice(untilEnd);
     }

--- a/test/date-only-rrule-until.test.js
+++ b/test/date-only-rrule-until.test.js
@@ -200,4 +200,41 @@ END:VCALENDAR`;
     const recurrences = event.rrule.all();
     assert.ok(recurrences.length > 0, 'Should have recurrences');
   });
+
+  it('should parse Outlook yearly date-only recurrence with UTC UNTIL offset', function () {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Microsoft Corporation//Outlook 16.0 MIMEDIR//EN
+BEGIN:VEVENT
+SUMMARY:Annual Company Anniversary
+DTSTART;VALUE=DATE:20261020
+DTEND;VALUE=DATE:20261021
+RRULE:FREQ=YEARLY;UNTIL=20261019T230000Z;INTERVAL=1;BYMONTHDAY=20;BYMONTH=10
+UID:test-outlook-rrule-until
+END:VEVENT
+END:VCALENDAR`;
+
+    const parsed = ical.sync.parseICS(ics);
+    const event = Object.values(parsed).find(event_ => event_.summary === 'Annual Company Anniversary');
+    assert.ok(event, 'Event should exist');
+    assert.strictEqual(event.start.dateOnly, true, 'Start should be date-only');
+
+    const instances = ical.expandRecurringEvent(event, {
+      from: new Date('2026-01-01'),
+      to: new Date('2027-01-01'),
+    });
+
+    assert.strictEqual(instances.length, 1, 'Should expand to 1 occurrence');
+    assert.strictEqual(instances[0].start.getFullYear(), 2026);
+    assert.strictEqual(instances[0].start.getMonth(), 9);
+    assert.strictEqual(instances[0].start.getDate(), 20);
+
+    const recurrences = event.rrule.all();
+    assert.strictEqual(recurrences.length, 1, 'Should have 1 recurrence via rrule.all()');
+    const firstDate = new Date(recurrences[0]);
+    assert.strictEqual(firstDate.getFullYear(), 2026);
+    assert.strictEqual(firstDate.getMonth(), 9);
+    assert.strictEqual(firstDate.getDate(), 20);
+  });
 });
+

--- a/test/date-only-rrule-until.test.js
+++ b/test/date-only-rrule-until.test.js
@@ -236,5 +236,29 @@ END:VCALENDAR`;
     assert.strictEqual(firstDate.getMonth(), 9);
     assert.strictEqual(firstDate.getDate(), 20);
   });
-});
 
+  it('should not normalize UNTIL when exactly 24 hours before DTSTART', function () {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+SUMMARY:Excluded Boundary Event
+DTSTART;VALUE=DATE:20261020
+DTEND;VALUE=DATE:20261021
+RRULE:FREQ=YEARLY;UNTIL=20261019T000000Z;INTERVAL=1;BYMONTHDAY=20;BYMONTH=10
+UID:test-boundary-until-24h
+END:VEVENT
+END:VCALENDAR`;
+
+    const parsed = ical.sync.parseICS(ics);
+    const event = Object.values(parsed).find(event_ => event_.summary === 'Excluded Boundary Event');
+    assert.ok(event, 'Event should exist');
+
+    const instances = ical.expandRecurringEvent(event, {
+      from: new Date('2026-01-01'),
+      to: new Date('2027-01-01'),
+    });
+
+    assert.strictEqual(instances.length, 0, 'Should not have occurrences since UNTIL is a full day before DTSTART');
+  });
+});


### PR DESCRIPTION
### Summary
When importing recurring all-day events (`VALUE=DATE`) exported by Microsoft Outlook / Office 365 / Exchange, recurring events occurring during timezones with positive UTC offsets (e.g., British Summer Time `UTC+1`, Central European Summer Time `UTC+2`, `IST`, etc.) produce **0 occurrences** during expansion and are dropped.

### Steps to Reproduce / Example VEVENT
Consider this raw event exported by Microsoft Outlook:

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Microsoft Corporation//Outlook 16.0 MIMEDIR//EN
BEGIN:VEVENT
SUMMARY:Annual Company Anniversary
DTSTART;VALUE=DATE:20261020
DTEND;VALUE=DATE:20261021
RRULE:FREQ=YEARLY;UNTIL=20261019T230000Z;INTERVAL=1;BYMONTHDAY=20;BYMONTH=10
UID:040000008200E00074C5B7101A82E008000000001770A99DCA20DD01000000000000000010000000D89CF7DF459ACA4D8297499F5D989862
END:VEVENT
END:VCALENDAR
```

When calling `ical.expandRecurringEvent(event, { from: new Date('2026-01-01'), to: new Date('2027-01-01') })`, the result is `[]` (empty array).

### Root Cause Analysis

1. **Outlook's Export Behavior:**
   When exporting an all-day event (`2026-10-20`) in a timezone with a positive offset (such as London during BST `UTC+1`), Outlook converts local midnight (`2026-10-20 00:00:00 BST`) to UTC (`2026-10-19 23:00:00 UTC`), generating `UNTIL=20261019T230000Z`.

2. **`node-ical`'s `dateOnly` Normalization in `ical.js`:**
   In `ical.js` (around line 913), `node-ical` normalizes `UNTIL` for `dateOnly` events by stripping the time portion with a regular expression:
   ```javascript
   if (curr.start.dateOnly) {
     // DATE-only: strip time from UNTIL
     if (timePart) {
       rruleOnly = rruleOnly.replace(/UNTIL=\d{8}T\d{6}Z?/v, `UNTIL=${datePart}`);
     }
   }
   ```
   Because `datePart` is extracted directly as string characters (`20261019`), the rule becomes:
   $$\text{DTSTART: } 20261020 \quad | \quad \text{UNTIL: } 20261019$$

3. **Recurrence Engine Failure:**
   `rrule-temporal` sees that `UNTIL` (October 19) is strictly before `DTSTART` (October 20). Because the recurrence mathematically ended before it began, `rrule.between()` returns `[]` (0 occurrences).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of date-only recurring events with UTC-formatted end dates.
  * Recurrences that cross midnight due to timezone offsets now retain the correct start date and expand as expected.
  * Preserved end dates exactly 24 hours before a date-only recurrence starts, preventing unintended occurrences.

* **Tests**
  * Added coverage for yearly date-only recurrences generated with UTC end timestamps, including the exact 24-hour boundary case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->